### PR TITLE
Implement filtering top-level tasks by jmespath query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ was generated from:
 ## Usage
 
 ```
-usage: eliottree.py [-h] [-u UUID] [-i KEY] [--raw] [FILE [FILE ...]]
+usage: eliot-tree [-h] [-u UUID] [-i KEY] [--raw] [--select EXPR]
+                  [FILE [FILE ...]]
 
 Display an Eliot log as a tree of tasks.
 
@@ -70,6 +71,9 @@ optional arguments:
                         standard keys.
   --raw                 Do not format some task values (such as timestamps) as
                         human-readable
+  --select QUERY        Select tasks to be displayed based on a jmespath
+                        query. If any child task is selected the entire top-
+                        level task is selected. See <http://jmespath.org/>
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ optional arguments:
   --raw                 Do not format some task values (such as timestamps) as
                         human-readable
   --select QUERY        Select tasks to be displayed based on a jmespath
-                        query. If any child task is selected the entire top-
-                        level task is selected. See <http://jmespath.org/>
+                        query, can be specified multiple times to mimic
+                        logical AND. If any child task is selected the entire
+                        top-level task is selected. See <http://jmespath.org/>
 ```
 
 ## Contribute

--- a/eliot_tree.py
+++ b/eliot_tree.py
@@ -190,7 +190,7 @@ def merge_tasktree(tasktree, fd, process_task=None, filter_func=None):
         read from ``fd``, that returns a transformed ``dict``.
     :param filter_func: Callable taking a single ``dict`` argument, the task
         read from ``fd``, that returns a ``bool`` indicating whether the task
-        should be filtered from the output; the entire task is displayed if any
+        should be included in the output; the entire task is displayed if any
         child task is selected.
     :return: Newly merged task tree.
     """

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
     ],
+    install_requires=[
+        "jmespath==0.7.1"
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         'Programming Language :: Python',
     ],
     install_requires=[
-        "jmespath==0.7.1"
+        "jmespath>=0.7.1"
     ],
 )


### PR DESCRIPTION
Top-level tasks can be filtered by a jmespath query that is applied to every processed task, if any child task is selected then the top-level task it belongs to will be selected too.

Closes #14.