### PR TITLE
Don't blow up on unnamed tasks

### DIFF
--- a/eliottree/test/tasks.py
+++ b/eliottree/test/tasks.py
@@ -1,3 +1,10 @@
+unnamed_message = {
+    u"task_uuid": u"cdeb220d-7605-4d5f-8341-1a170222e308",
+    u"error": False,
+    u"timestamp": 1425356700,
+    u"message": u"Main loop terminated.",
+    u"task_level": [1]}
+
 message_task = {
     u"task_uuid": u"cdeb220d-7605-4d5f-8341-1a170222e308",
     u"error": False,

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -2,7 +2,8 @@ from testtools import TestCase
 from testtools.matchers import Equals, Is, MatchesListwise, raises
 
 from eliottree.test.tasks import (
-    action_task, action_task_end, message_task, nested_action_task)
+    action_task, action_task_end, message_task, nested_action_task,
+    unnamed_message)
 from eliottree.tree import Tree, _TaskNode, task_name
 
 
@@ -36,6 +37,15 @@ class TaskNameTests(TestCase):
             task_name(action_task),
             Equals(u'app:action@1/started'))
 
+    def test_no_action_type(self):
+        """
+        If the task does not include either a ``message_type`` or an
+        ``action_type`` key, then return None.
+        """
+        self.assertThat(
+            task_name(unnamed_message),
+            Is(None))
+
     def test_levels(self):
         """
         Include the task level in the task name.
@@ -67,6 +77,16 @@ class TaskNodeTests(TestCase):
             repr(node),
             Equals('<_TaskNode f3a32bb3-ea6b-457c-aa99-08a3d0491ab4 '
                    'app:action@1/started children=0>'))
+
+    def test_repr_nameless(self):
+        """
+        Representation of a task without a name.
+        """
+        node = _TaskNode(task=unnamed_message)
+        self.assertThat(
+            repr(node),
+            Equals('<_TaskNode cdeb220d-7605-4d5f-8341-1a170222e308 '
+                   '{} children=0>'.format(_TaskNode._DEFAULT_TASK_NAME)))
 
     def test_repr_childen(self):
         """


### PR DESCRIPTION
Previously, eliottree would raise a stack trace if it came across a task that lacked a message or an action type.  This patch detects those cases and provides a sensible default.

```
5d91c6b3-dc05-492f-bae2-1e0a7c0b1fa1
    +-- run_process@1/started
        |-- args: []
        |-- command: [u'/bin/sh', u'-c', u'echo goodbye && exec false']
        |-- kwargs:
            |-- stderr: -2
            `-- stdout: -1
        `-- timestamp: 2015-06-29 13:17:05.646867
    +-- <UNNAMED TASK>
        |-- command: [u'/bin/sh', u'-c', u'echo goodbye && exec false']
        |-- output: goodbye [...]
        |-- status: 1
        `-- timestamp: 2015-06-29 13:17:05.652796
    +-- run_process@3/failed
        |-- exception: flocker.testtools._CalledProcessError
        |-- reason: Command '['/bin/sh', '-c', 'echo goodbye && exec false']' returned non-zero exit status 1 and output [...]
        `-- timestamp: 2015-06-29 13:17:05.653505
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/20)
<!-- Reviewable:end -->
