### PR TITLE
Adjust the interpretation of Eliot's tree structure 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,13 @@ This output:
 
 .. code-block::
 
-   $ eliot-tree < eliot.log
+   $ eliot-tree eliot.log
    f3a32bb3-ea6b-457c-aa99-08a3d0491ab4
-       +-- app:soap:client:request@1/started
-           |-- dump: /home/user/dump_files/20150303/1425356936.28_Client_req.xml
-           |-- soapAction: a_soap_action
-           |-- timestamp: 2015-03-03 06:28:56.278875
-           `-- uri: http://example.org/soap
+   +-- app:soap:client:request@1/started
+       |-- dump: /home/user/dump_files/20150303/1425356936.28_Client_req.xml
+       |-- soapAction: a_soap_action
+       |-- timestamp: 2015-03-03 06:28:56.278875
+       `-- uri: http://example.org/soap
        +-- app:soap:client:success@2,1/started
            `-- timestamp: 2015-03-03 06:28:57.516579
            +-- app:soap:client:success@2,2/succeeded
@@ -27,11 +27,11 @@ This output:
            `-- timestamp: 2015-03-03 06:28:57.517161
 
    89a56df5-d808-4a7c-8526-e603aae2e2f2
-       +-- app:soap:service:request@1/started
-           |-- dump: /home/user/dump_files/20150303/1425357068.03_Service_req.xml
-           |-- soapAction: method
-           |-- timestamp: 2015-03-03 06:31:08.032091
-           `-- uri: /endpoints/soap/method
+   +-- app:soap:service:request@1/started
+       |-- dump: /home/user/dump_files/20150303/1425357068.03_Service_req.xml
+       |-- soapAction: method
+       |-- timestamp: 2015-03-03 06:31:08.032091
+       `-- uri: /endpoints/soap/method
        +-- app:soap:service:success@2,1/started
            `-- timestamp: 2015-03-03 06:31:11.512330
            +-- app:soap:service:success@2,2/succeeded

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -113,16 +113,15 @@ def _render_task_node(write, node, field_limit, ignored_task_keys, encoding):
     :param encoding: Encoding to use when rendering.
     """
     _child_write = _indented_write(write)
-    if node.task is not None:
-        write(
-            '+-- {name}\n'.format(
-                name=node.name.encode(encoding)))
-        _render_task(
-            write=_child_write,
-            task=node.task,
-            field_limit=field_limit,
-            ignored_task_keys=ignored_task_keys,
-            encoding=encoding)
+    write(
+        '+-- {name}\n'.format(
+            name=node.name.encode(encoding)))
+    _render_task(
+        write=_child_write,
+        task=node.task,
+        field_limit=field_limit,
+        ignored_task_keys=ignored_task_keys,
+        encoding=encoding)
 
     for child in node.children():
         _render_task_node(
@@ -159,7 +158,7 @@ def render_task_nodes(write, nodes, field_limit, ignored_task_keys=None,
         ignored_task_keys = DEFAULT_IGNORED_KEYS
     for task_uuid, node in nodes:
         write('{name}\n'.format(
-            name=node.name.encode(encoding)))
+            name=node.task['task_uuid'].encode(encoding)))
         _render_task_node(
             write=write,
             node=node,

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -90,8 +90,8 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        `-- timestamp: 1425356800\n'
+                '+-- app:action@1/started\n'
+                '    `-- timestamp: 1425356800\n'
                 '    +-- app:action@2/succeeded\n'
                 '        `-- timestamp: 1425356800\n\n'))
 
@@ -111,10 +111,10 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        |-- message: this is a\n'
-                '            many line message\n'
-                '        `-- timestamp: 1425356800\n\n'))
+                '+-- app:action@1/started\n'
+                '    |-- message: this is a\n'
+                '        many line message\n'
+                '    `-- timestamp: 1425356800\n\n'))
 
     def test_multiline_field_limit(self):
         """
@@ -132,9 +132,9 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        |-- message: this is a [...]\n'
-                '        `-- timestamp: 1425356800\n\n'))
+                '+-- app:action@1/started\n'
+                '    |-- message: this is a [...]\n'
+                '    `-- timestamp: 1425356800\n\n'))
 
     def test_field_limit(self):
         """
@@ -151,11 +151,11 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'cdeb220d-7605-4d5f-8341-1a170222e308\n'
-                '    +-- twisted:log@1/None\n'
-                '        |-- error: False\n'
-                '        |-- message: Main  [...]\n'
-                '        |-- message_type: twist [...]\n'
-                '        `-- timestamp: 14253 [...]\n\n'))
+                '+-- twisted:log@1/None\n'
+                '    |-- error: False\n'
+                '    |-- message: Main  [...]\n'
+                '    |-- message_type: twist [...]\n'
+                '    `-- timestamp: 14253 [...]\n\n'))
 
     def test_ignored_keys(self):
         """
@@ -173,11 +173,11 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        |-- action_status: started\n'
-                '        |-- action_type: app:action\n'
-                '        |-- task_uuid: f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '        `-- timestamp: 1425356800\n\n'))
+                '+-- app:action@1/started\n'
+                '    |-- action_status: started\n'
+                '    |-- action_type: app:action\n'
+                '    |-- task_uuid: f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                '    `-- timestamp: 1425356800\n\n'))
 
     def test_task_data(self):
         """
@@ -194,11 +194,11 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'cdeb220d-7605-4d5f-8341-1a170222e308\n'
-                '    +-- twisted:log@1/None\n'
-                '        |-- error: False\n'
-                '        |-- message: Main loop terminated.\n'
-                '        |-- message_type: twisted:log\n'
-                '        `-- timestamp: 1425356700\n\n'))
+                '+-- twisted:log@1/None\n'
+                '    |-- error: False\n'
+                '    |-- message: Main loop terminated.\n'
+                '    |-- message_type: twisted:log\n'
+                '    `-- timestamp: 1425356700\n\n'))
 
     def test_dict_data(self):
         """
@@ -215,10 +215,10 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        |-- some_data:\n'
-                '            `-- a: 42\n'
-                '        `-- timestamp: 1425356800\n\n'))
+                '+-- app:action@1/started\n'
+                '    |-- some_data:\n'
+                '        `-- a: 42\n'
+                '    `-- timestamp: 1425356800\n\n'))
 
     def test_nested(self):
         """
@@ -232,7 +232,7 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
-                '    +-- app:action@1/started\n'
-                '        `-- timestamp: 1425356800\n'
-                '        +-- app:action:nested@1,1/started\n'
-                '            `-- timestamp: 1425356900\n\n'))
+                '+-- app:action@1/started\n'
+                '    `-- timestamp: 1425356800\n'
+                '    +-- app:action:nested@1,1/started\n'
+                '        `-- timestamp: 1425356900\n\n'))

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -6,6 +6,16 @@ from eliottree.test.tasks import (
 from eliottree.tree import Tree, _TaskNode, task_name
 
 
+def _flattened_tasks(nodes):
+    """
+    Construct a flat iterable of all the tasks for an iterable of nodes.
+    """
+    for n in nodes:
+        yield n.task
+        for c in n.children():
+            yield c.task
+
+
 class TaskNameTests(TestCase):
     """
     Tests for ``eliottree.tree.task_name``.
@@ -49,18 +59,17 @@ class TaskNodeTests(TestCase):
     """
     Tests for ``eliottree.tree._TaskNode``.
     """
-    def test_repr_root(self):
+    def test_none(self):
         """
-        Representation of a root node.
+        Passing ``None`` as the task value raises ``ValueError``
         """
-        node = _TaskNode(task=None, name=u'foo')
         self.assertThat(
-            repr(node),
-            Equals('<_TaskNode root foo children=0>'))
+            lambda: _TaskNode(task=None),
+            raises(ValueError))
 
     def test_repr(self):
         """
-        Representation of a normal task node.
+        Representation of a task node.
         """
         node = _TaskNode(task=action_task)
         self.assertThat(
@@ -72,31 +81,19 @@ class TaskNodeTests(TestCase):
         """
         Representation of a task node with children.
         """
-        node = _TaskNode(task=None, name=u'foo')
-        node.add_child(_TaskNode(task=action_task))
+        node = _TaskNode(task=action_task, name=u'foo')
+        node.add_child(_TaskNode(task=message_task))
         self.assertThat(
             repr(node),
-            Equals('<_TaskNode root foo children=1>'))
-
-    def test_first_child(self):
-        """
-        ``_TaskNode.first_child`` returns the first child node that was added.
-        """
-        node = _TaskNode(task=None, name=u'foo')
-        child = _TaskNode(task=action_task)
-        child2 = _TaskNode(task=action_task_end)
-        node.add_child(child2)
-        node.add_child(child)
-        self.assertThat(
-            node.first_child(),
-            Equals(child2))
+            Equals('<_TaskNode f3a32bb3-ea6b-457c-aa99-08a3d0491ab4 '
+                   'foo children=1>'))
 
     def test_no_children(self):
         """
         ``_TaskNode.children`` returns an empty list for a node with no
         children.
         """
-        node = _TaskNode(task=None, name=u'foo')
+        node = _TaskNode(task=action_task, name=u'foo')
         self.assertThat(
             node.children(),
             Equals([]))
@@ -106,8 +103,8 @@ class TaskNodeTests(TestCase):
         ``_TaskNode.children`` returns an list of child nodes sorted by their
         level regardless of the order they were added.
         """
-        node = _TaskNode(task=None, name=u'foo')
-        child = _TaskNode(task=action_task)
+        node = _TaskNode(task=action_task, name=u'foo')
+        child = _TaskNode(task=nested_action_task)
         child2 = _TaskNode(task=action_task_end)
         node.add_child(child2)
         node.add_child(child)
@@ -119,8 +116,8 @@ class TaskNodeTests(TestCase):
         """
         ``_TaskNode.children`` does not include grandchildren.
         """
-        node = _TaskNode(task=None, name=u'foo')
-        child = _TaskNode(task=action_task)
+        node = _TaskNode(task=action_task, name=u'foo')
+        child = _TaskNode(task=message_task)
         node.add_child(child)
         child2 = _TaskNode(task=nested_action_task)
         node.add_child(child2)
@@ -157,7 +154,7 @@ class TreeTests(TestCase):
             Equals(['cdeb220d-7605-4d5f-8341-1a170222e308',
                     'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4']))
         self.assertThat(
-            [c.task for n in nodes for c in n.children()],
+            list(_flattened_tasks(nodes)),
             MatchesListwise([Equals(message_task),
                              Equals(action_task)]))
 
@@ -174,7 +171,7 @@ class TreeTests(TestCase):
             list(keys),
             Equals(['f3a32bb3-ea6b-457c-aa99-08a3d0491ab4']))
         self.assertThat(
-            [c.task for n in nodes for c in n.children()],
+            list(_flattened_tasks(nodes)),
             MatchesListwise([Equals(action_task),
                              Equals(action_task_end)]))
 
@@ -193,6 +190,7 @@ class TreeTests(TestCase):
         self.expectThat(
             list(keys),
             Equals(list(matches)))
+
         self.assertThat(
-            [c.task for n in nodes for c in n.children()],
+            list(_flattened_tasks(nodes)),
             MatchesListwise([Equals(action_task)]))

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -175,6 +175,16 @@ class TreeTests(TestCase):
             MatchesListwise([Equals(action_task),
                              Equals(action_task_end)]))
 
+    def test_merge_startless_tasks(self):
+        """
+        Merging a task that will never have a start parent raises
+        ``RuntimeError``.
+        """
+        tree = Tree()
+        self.assertThat(
+            lambda: tree.merge_tasks([action_task_end]),
+            raises(RuntimeError))
+
     def test_merge_tasks_filtered(self):
         """
         Merge tasks into the tree with a filter function, generating a set of


### PR DESCRIPTION
The gist of this is that `task_level` `[1]` becomes the root node to which all subsequent task data is attached to.

(Closes issue #21.)