### PR TITLE
Less noisy message output

### DIFF
--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 
 DEFAULT_IGNORED_KEYS = set([
-    u'action_status', u'action_type', u'task_level', u'task_uuid'])
+    u'action_status', u'action_type', u'task_level', u'task_uuid',
+    u'message_type'])
 
 
 def _format_value(value, encoding):

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -151,10 +151,9 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'cdeb220d-7605-4d5f-8341-1a170222e308\n'
-                '+-- twisted:log@1/None\n'
+                '+-- twisted:log@1\n'
                 '    |-- error: False\n'
                 '    |-- message: Main  [...]\n'
-                '    |-- message_type: twist [...]\n'
                 '    `-- timestamp: 14253 [...]\n\n'))
 
     def test_ignored_keys(self):
@@ -194,10 +193,9 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             Equals(
                 'cdeb220d-7605-4d5f-8341-1a170222e308\n'
-                '+-- twisted:log@1/None\n'
+                '+-- twisted:log@1\n'
                 '    |-- error: False\n'
                 '    |-- message: Main loop terminated.\n'
-                '    |-- message_type: twisted:log\n'
                 '    `-- timestamp: 1425356700\n\n'))
 
     def test_dict_data(self):

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -36,7 +36,7 @@ class TaskNameTests(TestCase):
         """
         self.assertThat(
             task_name(message_task),
-            Equals(u'twisted:log@1/None'))
+            Equals(u'twisted:log@1'))
 
     def test_no_message_type(self):
         """

--- a/eliottree/tree.py
+++ b/eliottree/tree.py
@@ -13,13 +13,13 @@ def task_name(task):
     level = u','.join(map(unicode, task[u'task_level']))
     message_type = task.get('message_type', None)
     if message_type is not None:
-        status = None
+        status = u''
     elif message_type is None:
         message_type = task.get('action_type', None)
         if message_type is None:
             return None
-        status = task['action_status']
-    return u'{message_type}@{level}/{status}'.format(
+        status = u'/' + task['action_status']
+    return u'{message_type}@{level}{status}'.format(
         message_type=message_type,
         level=level,
         status=status)


### PR DESCRIPTION
Messages are currently repetitive (`message_type` contents included twice) and have extra noise at end (`/None`). This removes both.