### PR TITLE
Yield no matches instead of all tasks when no tasks match.

### DIFF
--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -224,3 +224,12 @@ class TreeTests(TestCase):
         self.assertThat(
             list(_flattened_tasks(nodes)),
             MatchesListwise([Equals(action_task)]))
+
+    def test_merge_tasks_no_matches(self):
+        """
+        Merging tasks when no tasks match returns an empty set of tasks.
+        """
+        tree = Tree()
+        matches = tree.merge_tasks(
+            [action_task, message_task], [lambda task: False])
+        self.expectThat(list(matches), Equals([]))

--- a/eliottree/tree.py
+++ b/eliottree/tree.py
@@ -112,7 +112,7 @@ class Tree(object):
         :return: Iterable of key and node pairs for top-level nodes, sorted by
             timestamp.
         """
-        if uuids:
+        if uuids is not None:
             nodes = ((k, self._nodes[k]) for k in uuids)
         else:
             nodes = self._nodes.iteritems()
@@ -135,10 +135,10 @@ class Tree(object):
             functions were specified.
         """
         tasktree = self._nodes
-        matches = defaultdict(set)
         if filter_funcs is None:
             filter_funcs = []
         filter_funcs = list(filter_funcs)
+        matches = dict((i, set()) for i, _ in enumerate(filter_funcs))
 
         def _merge(tasks):
             pending = []


### PR DESCRIPTION
Fixes #26.