### PR TITLE
Filter tasks by start and end date.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,10 @@ Usage
                            query, can be specified multiple times to mimic
                            logical AND. If any child task is selected the entire
                            top-level task is selected. See <http://jmespath.org/>
+     --start START         Select tasks whose timestamp occurs after (or on) an
+                           ISO8601 date.
+     --end END             Select tasks whose timestamp occurs before an ISO8601
+                           date.
 
 Contribute
 ----------

--- a/eliottree/__init__.py
+++ b/eliottree/__init__.py
@@ -1,7 +1,11 @@
-from eliottree.filter import filter_by_jmespath, filter_by_uuid
+from eliottree.filter import (
+    filter_by_end_date, filter_by_jmespath, filter_by_start_date,
+    filter_by_uuid)
 from eliottree.render import render_task_nodes
 from eliottree.tree import Tree
 
 
 __all__ = [
-    'Tree', 'render_task_nodes', 'filter_by_jmespath', 'filter_by_uuid']
+    'Tree', 'render_task_nodes', 'filter_by_jmespath', 'filter_by_uuid',
+    'filter_by_start_date', 'filter_by_end_date',
+]

--- a/eliottree/_cli.py
+++ b/eliottree/_cli.py
@@ -13,7 +13,8 @@ from eliottree import (
     filter_by_uuid, render_task_nodes)
 
 
-def build_task_nodes(files=None, select=None, task_uuid=None, start=None, end=None):
+def build_task_nodes(files=None, select=None, task_uuid=None, start=None,
+                     end=None):
     """
     Build the task nodes given some input data, query criteria and formatting
     options.

--- a/eliottree/_cli.py
+++ b/eliottree/_cli.py
@@ -4,19 +4,26 @@ import json
 import sys
 from itertools import chain
 
+import iso8601
 from six import PY3
 from six.moves import map
 
 from eliottree import (
-    Tree, filter_by_jmespath, filter_by_uuid, render_task_nodes)
+    Tree, filter_by_end_date, filter_by_jmespath, filter_by_start_date,
+    filter_by_uuid, render_task_nodes)
 
 
-def build_task_nodes(files=None, select=None, task_uuid=None):
+def build_task_nodes(files=None, select=None, task_uuid=None, start=None, end=None):
     """
     Build the task nodes given some input data, query criteria and formatting
     options.
     """
     def filter_funcs():
+        if start:
+            yield filter_by_start_date(start)
+        if end:
+            yield filter_by_end_date(end)
+
         if select is not None:
             for query in select:
                 yield filter_by_jmespath(query)
@@ -48,7 +55,9 @@ def display_task_tree(args):
     nodes = build_task_nodes(
         files=args.files,
         select=args.select,
-        task_uuid=args.task_uuid)
+        task_uuid=args.task_uuid,
+        start=args.start,
+        end=args.end)
     render_task_nodes(
         write=write,
         nodes=nodes,
@@ -98,5 +107,15 @@ def main():
                         query, can be specified multiple times to mimic logical
                         AND. If any child task is selected the entire top-level
                         task is selected. See <http://jmespath.org/>''')
+    parser.add_argument('--start',
+                        dest='start',
+                        type=iso8601.parse_date,
+                        help='''Select tasks whose timestamp occurs after (or
+                        on) an ISO8601 date.''')
+    parser.add_argument('--end',
+                        dest='end',
+                        type=iso8601.parse_date,
+                        help='''Select tasks whose timestamp occurs before an
+                        ISO8601 date.''')
     args = parser.parse_args()
     display_task_tree(args)

--- a/eliottree/filter.py
+++ b/eliottree/filter.py
@@ -1,10 +1,12 @@
+from datetime import datetime
+
 import jmespath
+from iso8601.iso8601 import Utc
 
 
 def filter_by_jmespath(query):
     """
-    A factory function producing a filter function for filtering a task by
-    a jmespath query expression.
+    Produce a function for filtering a task by a jmespath query expression.
     """
     def _filter(task):
         return bool(expn.search(task))
@@ -14,10 +16,40 @@ def filter_by_jmespath(query):
 
 def filter_by_uuid(task_uuid):
     """
-    A factory function producing a filter function for filtering tasks by their
-    UUID.
+    Produce a function for filtering tasks by their UUID.
     """
     return filter_by_jmespath('task_uuid == `{}`'.format(task_uuid))
 
 
-__all__ = ['filter_by_jmespath', 'filter_by_uuid']
+def _parse_timestamp(timestamp):
+    """
+    Parse a timestamp into a UTC L{datetime}.
+    """
+    return datetime.utcfromtimestamp(timestamp).replace(tzinfo=Utc())
+
+
+def filter_by_start_date(start_date):
+    """
+    Produce a function for filtering by task timestamps after (or on) a certain
+    date and time.
+    """
+    def _filter(task):
+        print repr(start_date)
+        return _parse_timestamp(task['timestamp']) >= start_date
+    return _filter
+
+
+def filter_by_end_date(end_date):
+    """
+    Produce a function for filtering by task timestamps before a certain date
+    and time.
+    """
+    def _filter(task):
+        return _parse_timestamp(task['timestamp']) < end_date
+    return _filter
+
+
+__all__ = [
+    'filter_by_jmespath', 'filter_by_uuid', 'filter_by_start_date',
+    'filter_by_end_date',
+]

--- a/eliottree/filter.py
+++ b/eliottree/filter.py
@@ -34,7 +34,6 @@ def filter_by_start_date(start_date):
     date and time.
     """
     def _filter(task):
-        print repr(start_date)
         return _parse_timestamp(task['timestamp']) >= start_date
     return _filter
 

--- a/eliottree/test/test_filter.py
+++ b/eliottree/test/test_filter.py
@@ -1,11 +1,17 @@
+from calendar import timegm
+from datetime import datetime
+
+from iso8601.iso8601 import Utc
 from testtools import TestCase
 from testtools.matchers import Equals
 
-from eliottree import filter_by_jmespath, filter_by_uuid
+from eliottree import (
+    filter_by_end_date, filter_by_jmespath, filter_by_start_date,
+    filter_by_uuid)
 from eliottree.test.tasks import action_task, message_task
 
 
-class FilterForJmespath(TestCase):
+class FilterByJmespath(TestCase):
     """
     Tests for ``eliottree.filter_by_jmespath``.
     """
@@ -26,7 +32,7 @@ class FilterForJmespath(TestCase):
             Equals(True))
 
 
-class FilterForUUID(TestCase):
+class FilterByUUID(TestCase):
     """
     Tests for ``eliottree.filter_by_uuid``.
     """
@@ -45,4 +51,90 @@ class FilterForUUID(TestCase):
         self.assertThat(
             filter_by_uuid('cdeb220d-7605-4d5f-8341-1a170222e308')(
                 message_task),
+            Equals(True))
+
+
+class FilterByStartDate(TestCase):
+    """
+    Tests for ``eliottree.filter_by_start_date``.
+    """
+    def test_no_match(self):
+        """
+        Return ``False`` if the input task's timestamp is before the start
+        date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 1, 0).utctimetuple()))
+        self.assertThat(
+            filter_by_start_date(now)(task),
+            Equals(False))
+
+    def test_match(self):
+        """
+        Return ``True`` if the input task's timestamp is after the start date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 2).utctimetuple()))
+        self.assertThat(
+            filter_by_start_date(now)(task),
+            Equals(True))
+
+    def test_match_moment(self):
+        """
+        Return ``True`` if the input task's timestamp is the same as the start
+        date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 1, 15).utctimetuple()))
+        self.assertThat(
+            filter_by_start_date(now)(task),
+            Equals(True))
+
+
+class FilterByEndDate(TestCase):
+    """
+    Tests for ``eliottree.filter_by_end_date``.
+    """
+    def test_no_match(self):
+        """
+        Return ``False`` if the input task's timestamp is after the start
+        date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 2).utctimetuple()))
+        self.assertThat(
+            filter_by_end_date(now)(task),
+            Equals(False))
+
+    def test_no_match_moment(self):
+        """
+        Return ``False`` if the input task's timestamp is the same as the start
+        date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 1, 15).utctimetuple()))
+        self.assertThat(
+            filter_by_end_date(now)(task),
+            Equals(False))
+
+    def test_match(self):
+        """
+        Return ``True`` if the input task's timestamp is before the start date.
+        """
+        now = datetime(2015, 10, 30, 22, 1, 15).replace(tzinfo=Utc())
+        task = dict(
+            message_task,
+            timestamp=timegm(datetime(2015, 10, 30, 22, 1).utctimetuple()))
+        self.assertThat(
+            filter_by_end_date(now)(task),
             Equals(True))

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         "six>=1.9.0",
         "jmespath>=0.7.1",
+        "iso8601>=0.1.10",
     ],
     extras_require={
         "dev": ["pytest>=2.7.1", "testtools>=1.8.0"],


### PR DESCRIPTION
Allow filtering tasks by the date they occur after (or on) and the date they occur before with the `--start` and `--end` command-line parameters.

Fixes #38.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/41)
<!-- Reviewable:end -->
