### PR TITLE
Translate control characters to Unicode control picture equivalents.

### DIFF
--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from six import PY3, binary_type, text_type
+from six import PY3, binary_type, text_type, unichr
 
 
 DEFAULT_IGNORED_KEYS = set([
@@ -29,7 +29,7 @@ def _format_value_hint(value, hint):
     return None
 
 
-controlEquivalents = dict((i, unichr(0x2400 + i)) for i in xrange(0x20))
+controlEquivalents = dict((i, unichr(0x2400 + i)) for i in range(0x20))
 controlEquivalents[0x0a] = u'\n'
 controlEquivalents[0x7f] = u'\u2421'
 
@@ -38,7 +38,7 @@ def _escape_control_characters(s):
     """
     Escape terminal control characters.
     """
-    return unicode(s).translate(controlEquivalents)
+    return text_type(s).translate(controlEquivalents)
 
 
 def _format_value(value, field_hint=None, human_readable=False):
@@ -88,7 +88,7 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
     """
     Render a single ``_TaskNode`` as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``unicode`` argument
+    :type write: ``callable`` taking a single ``text_type`` argument
     :param write: Callable to write the output.
 
     :type task: ``dict`` of ``text_type``:``Any``
@@ -128,7 +128,7 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
                 else:
                     lines = _value.splitlines() or [u'']
                     first_line = lines.pop(0)
-                assert isinstance(first_line, unicode)
+                assert isinstance(first_line, text_type)
                 write(
                     u'{tree_char}-- {key}: {value}\n'.format(
                         tree_char=tree_char,
@@ -144,7 +144,7 @@ def _render_task_node(write, node, field_limit, ignored_task_keys,
     """
     Render a single ``_TaskNode`` as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``unicode`` argument
+    :type write: ``callable`` taking a single ``text_type`` argument
     :param write: Callable to write the output.
 
     :type node: ``_TaskNode)``
@@ -183,7 +183,7 @@ def render_task_nodes(write, nodes, field_limit, ignored_task_keys=None,
     """
     Render a tree of task nodes as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``unicode`` argument
+    :type write: ``callable`` taking a single ``text_type`` argument
     :param write: Callable to write the output.
 
     :type nodes: ``list`` of ``(text_type, _TaskNode)``.

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -29,15 +29,30 @@ def _format_value_hint(value, hint):
     return None
 
 
+controlEquivalents = dict((i, unichr(0x2400 + i)) for i in xrange(0x20))
+controlEquivalents[0x0a] = u'\n'
+controlEquivalents[0x7f] = u'\u2421'
+
+
+def _escape_control_characters(s):
+    """
+    Escape terminal control characters.
+    """
+    return unicode(s).translate(controlEquivalents)
+
+
 def _format_value(value, field_hint=None, human_readable=False):
     """
     Format a value for a task tree.
     """
-    if isinstance(value, text_type):
-        return value
-    elif isinstance(value, binary_type):
+    if isinstance(value, binary_type):
         # We guess bytes values are UTF-8.
-        return value.decode('utf-8', 'replace')
+        print 'hello'
+        value = value.decode('utf-8', 'replace')
+
+    if isinstance(value, text_type):
+        return _escape_control_characters(value)
+
     if human_readable:
         formatted = _format_value_raw(value)
         if formatted is None:

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -47,7 +47,6 @@ def _format_value(value, field_hint=None, human_readable=False):
     """
     if isinstance(value, binary_type):
         # We guess bytes values are UTF-8.
-        print 'hello'
         value = value.decode('utf-8', 'replace')
 
     if isinstance(value, text_type):

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -113,7 +113,7 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
                 write(
                     u'{tree_char}-- {key}:\n'.format(
                         tree_char=tree_char,
-                        key=key))
+                        key=_escape_control_characters(key)))
                 _render_task(write=_write,
                              task=value,
                              ignored_task_keys={},
@@ -132,7 +132,7 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
                 write(
                     u'{tree_char}-- {key}: {value}\n'.format(
                         tree_char=tree_char,
-                        key=key,
+                        key=_escape_control_characters(key),
                         value=first_line))
                 if not field_limit:
                     for line in lines:
@@ -161,7 +161,7 @@ def _render_task_node(write, node, field_limit, ignored_task_keys,
     :param human_readable: Should this be rendered as human-readable?
     """
     _child_write = _indented_write(write)
-    write(u'+-- {name}\n'.format(name=node.name))
+    write(u'+-- {name}\n'.format(name=_escape_control_characters(node.name)))
     _render_task(
         write=_child_write,
         task=node.task,
@@ -203,7 +203,8 @@ def render_task_nodes(write, nodes, field_limit, ignored_task_keys=None,
     if ignored_task_keys is None:
         ignored_task_keys = DEFAULT_IGNORED_KEYS
     for task_uuid, node in nodes:
-        write(u'{name}\n'.format(name=node.task['task_uuid']))
+        write(u'{name}\n'.format(
+            name=_escape_control_characters(node.task['task_uuid'])))
         _render_task_node(
             write=write,
             node=node,

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -66,10 +66,10 @@ def _format_value(value, field_hint=None, human_readable=False):
 
 def _indented_write(write):
     """
-    Wrap ``write`` to instead write indented bytes.
+    Wrap ``write`` to instead write indented text.
     """
     def _write(data):
-        write('    ' + data)
+        write(u'    ' + data)
     return _write
 
 
@@ -77,10 +77,10 @@ def _truncate_value(value, limit):
     """
     Truncate values longer than ``limit``.
     """
-    values = value.split('\n')
+    values = value.split(u'\n')
     value = values[0]
     if len(value) > limit or len(values) > 1:
-        return '{} [...]'.format(value[:limit])
+        return u'{} [...]'.format(value[:limit])
     return value
 
 
@@ -88,7 +88,7 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
     """
     Render a single ``_TaskNode`` as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``bytes`` argument
+    :type write: ``callable`` taking a single ``unicode`` argument
     :param write: Callable to write the output.
 
     :type task: ``dict`` of ``text_type``:``Any``
@@ -108,10 +108,10 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
     num_items = len(task)
     for i, (key, value) in enumerate(sorted(task.items()), 1):
         if key not in ignored_task_keys:
-            tree_char = '`' if i == num_items else '|'
+            tree_char = u'`' if i == num_items else u'|'
             if isinstance(value, dict):
                 write(
-                    '{tree_char}-- {key}:\n'.format(
+                    u'{tree_char}-- {key}:\n'.format(
                         tree_char=tree_char,
                         key=key))
                 _render_task(write=_write,
@@ -128,14 +128,15 @@ def _render_task(write, task, ignored_task_keys, field_limit, human_readable):
                 else:
                     lines = _value.splitlines() or [u'']
                     first_line = lines.pop(0)
+                assert isinstance(first_line, unicode)
                 write(
-                    '{tree_char}-- {key}: {value}\n'.format(
+                    u'{tree_char}-- {key}: {value}\n'.format(
                         tree_char=tree_char,
                         key=key,
                         value=first_line))
                 if not field_limit:
                     for line in lines:
-                        _write(line + '\n')
+                        _write(line + u'\n')
 
 
 def _render_task_node(write, node, field_limit, ignored_task_keys,
@@ -143,7 +144,7 @@ def _render_task_node(write, node, field_limit, ignored_task_keys,
     """
     Render a single ``_TaskNode`` as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``bytes`` argument
+    :type write: ``callable`` taking a single ``unicode`` argument
     :param write: Callable to write the output.
 
     :type node: ``_TaskNode)``
@@ -160,8 +161,7 @@ def _render_task_node(write, node, field_limit, ignored_task_keys,
     :param human_readable: Should this be rendered as human-readable?
     """
     _child_write = _indented_write(write)
-    write(
-        '+-- {name}\n'.format(name=node.name))
+    write(u'+-- {name}\n'.format(name=node.name))
     _render_task(
         write=_child_write,
         task=node.task,
@@ -183,7 +183,7 @@ def render_task_nodes(write, nodes, field_limit, ignored_task_keys=None,
     """
     Render a tree of task nodes as an ``ASCII`` tree.
 
-    :type write: ``callable`` taking a single ``bytes`` argument
+    :type write: ``callable`` taking a single ``unicode`` argument
     :param write: Callable to write the output.
 
     :type nodes: ``list`` of ``(text_type, _TaskNode)``.
@@ -203,14 +203,14 @@ def render_task_nodes(write, nodes, field_limit, ignored_task_keys=None,
     if ignored_task_keys is None:
         ignored_task_keys = DEFAULT_IGNORED_KEYS
     for task_uuid, node in nodes:
-        write('{name}\n'.format(name=node.task['task_uuid']))
+        write(u'{name}\n'.format(name=node.task['task_uuid']))
         _render_task_node(
             write=write,
             node=node,
             field_limit=field_limit,
             ignored_task_keys=ignored_task_keys,
             human_readable=human_readable)
-        write('\n')
+        write(u'\n')
 
 
 __all__ = ['render_task_nodes']

--- a/eliottree/test/tasks.py
+++ b/eliottree/test/tasks.py
@@ -50,3 +50,21 @@ multiline_action_task = {
     u"action_type": u"app:action",
     u"task_level": [1],
     u"message": u"this is a\nmany line message"}
+
+janky_action_task = {
+    u"timestamp": '1425356800\x1b(0',
+    u"action_status": u"started\x1b(0",
+    u"task_uuid": u"f3a32bb3-ea6b-457c-\x1b(0aa99-08a3d0491ab4",
+    u"action_type": u"A\x1b(0",
+    u"task_level": [1],
+    u"message": u"hello\x1b(0world",
+    u"\x1b(0": "nope",
+    u"\x1b(0": {u"\x1b(0": "nope"}}
+
+janky_message_task = {
+    u"task_uuid": u"cdeb220d-7605-4d5f-\x1b(08341-1a170222e308",
+    u"error": False,
+    u"timestamp": 1425356700,
+    u"message": u"Main loop\x1b(0terminated.",
+    u"message_type": u"M\x1b(0",
+    u"task_level": [1]}

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -32,9 +32,18 @@ class FormatValueTests(TestCase):
             _format_value(u('\N{SNOWMAN}')),
             Equals(u('\N{SNOWMAN}')))
 
-    def test_str(self):
+    def test_unicode_control_characters(self):
         """
-        Assume that ``str`` values are UTF-8.
+        Translate control characters to their Unicode "control picture"
+        equivalent, instead of destroying a terminal.
+        """
+        self.assertThat(
+            _format_value(u('hello\001world')),
+            Equals(u('hello\u2401world')))
+
+    def test_bytes(self):
+        """
+        Assume that ``bytes`` values are UTF-8.
         """
         self.assertThat(
             _format_value(b'foo'),

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -12,10 +12,14 @@ from eliottree.test.tasks import (
     nested_action_task)
 
 
-ExactlyEquals = lambda value: MatchesAll(
-    IsInstance(type(value)),
-    Equals(value),
-    first_only=True)
+def ExactlyEquals(value):
+    """
+    Like `Equals` but also requires that the types match.
+    """
+    return MatchesAll(
+        IsInstance(type(value)),
+        Equals(value),
+        first_only=True)
 
 
 class FormatValueTests(TestCase):


### PR DESCRIPTION
This avoids unnecessarily trashing the terminal if any control characters
appear in any Eliot fields or keys.

Fixes #44.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/45)
<!-- Reviewable:end -->
