### PR TITLE
Use Eliot's builtin parser.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ eliottree
 
 |build|_ |coverage|_
 
-Render `Eliot <https://github.com/ClusterHQ/eliot>`_ logs as an ASCII tree.
+Render `Eliot <https://github.com/scatterhq/eliot>`_ logs as an ASCII tree.
 
 This output:
 
@@ -12,34 +12,34 @@ This output:
 
    $ eliot-tree eliot.log
    f3a32bb3-ea6b-457c-aa99-08a3d0491ab4
-   +-- app:soap:client:request@1/started
-       |-- dump: /home/user/dump_files/20150303/1425356936.28_Client_req.xml
-       |-- soapAction: a_soap_action
-       |-- timestamp: 2015-03-03 04:28:56.278875
-       `-- uri: http://example.org/soap
-       +-- app:soap:client:success@2,1/started
-           `-- timestamp: 2015-03-03 04:28:57.516579
-           +-- app:soap:client:success@2,2/succeeded
-               |-- dump: /home/user/dump_files/20150303/1425356937.52_Client_res.xml
-               `-- timestamp: 2015-03-03 04:28:57.517077
-       +-- app:soap:client:request@3/succeeded
-           |-- status: 200
-           `-- timestamp: 2015-03-03 04:28:57.517161
-
+   └── app:soap:client:request/1 ⇒ started
+       ├── dump: /home/user/dump_files/20150303/1425356936.28_Client_req.xml
+       ├── soapAction: a_soap_action
+       ├── timestamp: 2015-03-03 04:28:56.278875
+       ├── uri: http://example.org/soap
+       ├── app:soap:client:success/2/1 ⇒ started
+       │   ├── timestamp: 2015-03-03 04:28:57.516579
+       │   └── app:soap:client:success/2/2 ⇒ succeeded
+       │       ├── dump: /home/user/dump_files/20150303/1425356937.52_Client_res.xml
+       │       └── timestamp: 2015-03-03 04:28:57.517077
+       └── app:soap:client:request/3 ⇒ succeeded
+           ├── status: 200
+           └── timestamp: 2015-03-03 04:28:57.517161
+   
    89a56df5-d808-4a7c-8526-e603aae2e2f2
-   +-- app:soap:service:request@1/started
-       |-- dump: /home/user/dump_files/20150303/1425357068.03_Service_req.xml
-       |-- soapAction: method
-       |-- timestamp: 2015-03-03 04:31:08.032091
-       `-- uri: /endpoints/soap/method
-       +-- app:soap:service:success@2,1/started
-           `-- timestamp: 2015-03-03 04:31:11.512330
-           +-- app:soap:service:success@2,2/succeeded
-               |-- dump: /home/user/dump_files/20150303/1425357071.51_Service_res.xml
-               `-- timestamp: 2015-03-03 04:31:11.513453
-       +-- app:soap:service:request@3/succeeded
-           |-- status: 200
-           `-- timestamp: 2015-03-03 04:31:11.513992
+   └── app:soap:service:request/1 ⇒ started
+       ├── dump: /home/user/dump_files/20150303/1425357068.03_Service_req.xml
+       ├── soapAction: method
+       ├── timestamp: 2015-03-03 04:31:08.032091
+       ├── uri: /endpoints/soap/method
+       ├── app:soap:service:success/2/1 ⇒ started
+       │   ├── timestamp: 2015-03-03 04:31:11.512330
+       │   └── app:soap:service:success/2/2 ⇒ succeeded
+       │       ├── dump: /home/user/dump_files/20150303/1425357071.51_Service_res.xml
+       │       └── timestamp: 2015-03-03 04:31:11.513453
+       └── app:soap:service:request/3 ⇒ succeeded
+           ├── status: 200
+           └── timestamp: 2015-03-03 04:31:11.513992
 
 was generated from:
 
@@ -54,11 +54,22 @@ was generated from:
    {"task_uuid": "89a56df5-d808-4a7c-8526-e603aae2e2f2", "action_type": "app:soap:service:success", "dump": "/home/user/dump_files/20150303/1425357071.51_Service_res.xml", "timestamp": 1425357071.513453, "action_status": "succeeded", "task_level": [2, 2]}
    {"status": 200, "task_uuid": "89a56df5-d808-4a7c-8526-e603aae2e2f2", "task_level": [3], "action_type": "app:soap:service:request", "timestamp": 1425357071.513992, "action_status": "succeeded"}
 
-Usage
------
+Usage from Python
+-----------------
 
-.. code-block::
+.. code-block:: python
 
+   import json, sys
+   from eliottree import tasks_from_iterable, render_tasks
+   # Or `codecs.getwriter('utf-8')(sys.stdout).write` on Python 2.
+   render_tasks(sys.stdout.write, tasks, colorize=True)
+
+See :code:`help(render_tasks)` from a Python REPL for more information.
+
+Usage from the command-line
+---------------------------
+
+   $ eliot-tree 
    usage: eliot-tree [-h] [-u UUID] [-i KEY] [--raw]
                      [--color {always,auto,never}] [--no-colorize] [-l LENGTH]
                      [--select QUERY] [--start START] [--end END]

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,8 @@ Python REPL for more information.
 Usage from the command-line
 ---------------------------
 
+.. code-block::
+
    $ eliot-tree 
    usage: eliot-tree [-h] [-u UUID] [-i KEY] [--raw]
                      [--color {always,auto,never}] [--no-colorize] [-l LENGTH]

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ Usage from Python
    # Or `codecs.getwriter('utf-8')(sys.stdout).write` on Python 2.
    render_tasks(sys.stdout.write, tasks, colorize=True)
 
-See :code:`help(render_tasks)` from a Python REPL for more information.
+See :code:`help(render_tasks)` and :code:`help(tasks_from_iterable)` from a
+Python REPL for more information.
 
 Usage from the command-line
 ---------------------------

--- a/eliottree/__init__.py
+++ b/eliottree/__init__.py
@@ -1,8 +1,9 @@
 from eliottree._parse import tasks_from_iterable
+from eliottree._render import render_tasks
 from eliottree.filter import (
     filter_by_end_date, filter_by_jmespath, filter_by_start_date,
     filter_by_uuid)
-from eliottree.render import render_task_nodes, render_tasks
+from eliottree.render import render_task_nodes
 from eliottree.tree import Tree
 
 

--- a/eliottree/__init__.py
+++ b/eliottree/__init__.py
@@ -1,15 +1,16 @@
+from eliottree._errors import EliotParseError, JSONParseError
 from eliottree._parse import tasks_from_iterable
 from eliottree._render import render_tasks
 from eliottree.filter import (
     filter_by_end_date, filter_by_jmespath, filter_by_start_date,
     filter_by_uuid)
 from eliottree.render import render_task_nodes
-from eliottree.tree import TaskMergeError, Tree
+from eliottree.tree import Tree
 
 
 __all__ = [
     'Tree', 'render_task_nodes', 'render_task_nodes_unicode',
     'filter_by_jmespath', 'filter_by_uuid', 'filter_by_start_date',
     'filter_by_end_date', 'render_tasks', 'tasks_from_iterable',
-    'TaskMergeError',
+    'EliotParseError', 'JSONParseError',
 ]

--- a/eliottree/__init__.py
+++ b/eliottree/__init__.py
@@ -1,12 +1,13 @@
+from eliottree._parse import tasks_from_iterable
 from eliottree.filter import (
     filter_by_end_date, filter_by_jmespath, filter_by_start_date,
     filter_by_uuid)
-from eliottree.render import render_task_nodes, render_task_nodes_unicode
+from eliottree.render import render_task_nodes, render_tasks
 from eliottree.tree import Tree
 
 
 __all__ = [
     'Tree', 'render_task_nodes', 'render_task_nodes_unicode',
     'filter_by_jmespath', 'filter_by_uuid', 'filter_by_start_date',
-    'filter_by_end_date',
+    'filter_by_end_date', 'render_tasks', 'tasks_from_iterable',
 ]

--- a/eliottree/_cli.py
+++ b/eliottree/_cli.py
@@ -5,48 +5,48 @@ import sys
 from itertools import chain
 
 import iso8601
-from six import PY3
-from six.moves import map
+from six import PY3, binary_type
+from six.moves import filter, map
+from toolz import compose
 
 from eliottree import (
-    Tree, filter_by_end_date, filter_by_jmespath, filter_by_start_date,
-    filter_by_uuid, render_task_nodes_unicode)
+    filter_by_end_date, filter_by_jmespath, filter_by_start_date,
+    filter_by_uuid, render_tasks, tasks_from_iterable)
 
 
-def build_task_nodes(files=None, select=None, task_uuid=None, start=None,
-                     end=None):
+def parse_messages(files=None, select=None, task_uuid=None, start=None,
+                   end=None):
     """
-    Build the task nodes given some input data, query criteria and formatting
-    options.
+    Parse message dictionaries from inputs into Eliot tasks, filtering by any
+    provided criteria.
     """
     def filter_funcs():
+        if task_uuid is not None:
+            yield filter_by_uuid(task_uuid)
         if start:
             yield filter_by_start_date(start)
         if end:
             yield filter_by_end_date(end)
-
         if select is not None:
             for query in select:
                 yield filter_by_jmespath(query)
-
-        if task_uuid is not None:
-            yield filter_by_uuid(task_uuid)
 
     if not files:
         if PY3:
             files = [sys.stdin]
         else:
             files = [codecs.getreader('utf-8')(sys.stdin)]
+    return tasks_from_iterable(
+        sorted(
+            filter(compose(*filter_funcs()),
+                   map(json.loads, chain.from_iterable(files))),
+            key=lambda task: task.get(u'timestamp')))
 
-    tree = Tree()
-    tasks = map(json.loads, chain.from_iterable(files))
-    return tree.nodes(tree.merge_tasks(tasks, filter_funcs()))
 
-
-def display_task_tree(args):
+def display_tasks(args):
     """
     Read the input files, apply any command-line-specified behaviour and
-    display the task tree.
+    render the task trees to stdout.
     """
     if PY3:
         write = sys.stdout.write
@@ -58,19 +58,28 @@ def display_task_tree(args):
     else:
         colorize = args.color == 'always'
 
-    nodes = build_task_nodes(
+    tasks = parse_messages(
         files=args.files,
         select=args.select,
         task_uuid=args.task_uuid,
         start=args.start,
         end=args.end)
-    render_task_nodes_unicode(
+    render_tasks(
         write=write,
-        nodes=nodes,
-        ignored_task_keys=set(args.ignored_task_keys) or None,
+        tasks=tasks,
+        ignored_fields=set(args.ignored_fields) or None,
         field_limit=args.field_limit,
         human_readable=args.human_readable,
         colorize=colorize)
+
+
+def _decode_command_line(value, encoding='utf-8'):
+    """
+    Decode a command-line argument.
+    """
+    if isinstance(value, binary_type):
+        return value.decode(encoding)
+    return value
 
 
 def main():
@@ -84,12 +93,14 @@ def main():
     parser.add_argument('-u', '--task-uuid',
                         dest='task_uuid',
                         metavar='UUID',
+                        type=_decode_command_line,
                         help='''Select a specific task by UUID''')
     parser.add_argument('-i', '--ignore-task-key',
                         action='append',
                         default=[],
-                        dest='ignored_task_keys',
+                        dest='ignored_fields',
                         metavar='KEY',
+                        type=_decode_command_line,
                         help='''Ignore a task key, use multiple times to ignore
                         multiple keys. Defaults to ignoring most Eliot standard
                         keys.''')
@@ -116,6 +127,7 @@ def main():
                         action='append',
                         metavar='QUERY',
                         dest='select',
+                        type=_decode_command_line,
                         help='''Select tasks to be displayed based on a jmespath
                         query, can be specified multiple times to mimic logical
                         AND. If any child task is selected the entire top-level
@@ -131,4 +143,4 @@ def main():
                         help='''Select tasks whose timestamp occurs before an
                         ISO8601 date.''')
     args = parser.parse_args()
-    display_task_tree(args)
+    display_tasks(args)

--- a/eliottree/_errors.py
+++ b/eliottree/_errors.py
@@ -1,0 +1,22 @@
+class EliotParseError(RuntimeError):
+    """
+    An error occurred while parsing a particular Eliot message dictionary.
+    """
+    def __init__(self, message_dict, exc_info):
+        self.message_dict = message_dict
+        self.exc_info = exc_info
+        RuntimeError.__init__(self)
+
+
+class JSONParseError(RuntimeError):
+    """
+    An error occurred while parsing JSON text.
+    """
+    def __init__(self, file_name, line_number, line, exc_info):
+        self.file_name = file_name
+        self.line_number = line_number
+        self.line = line
+        self.exc_info = exc_info
+
+
+__all__ = ['EliotParseError', 'JSONParseError']

--- a/eliottree/_parse.py
+++ b/eliottree/_parse.py
@@ -1,4 +1,8 @@
+import sys
+
 from eliot._parse import Parser
+
+from eliottree._errors import EliotParseError
 
 
 def tasks_from_iterable(iterable):
@@ -11,7 +15,16 @@ def tasks_from_iterable(iterable):
     :return: Iterable of parsed Eliot tasks, suitable for use with
     `eliottree.render_tasks`.
     """
-    return Parser.parse_stream(iterable)
+    parser = Parser()
+    for message_dict in iterable:
+        try:
+            completed, parser = parser.add(message_dict)
+            for task in completed:
+                yield task
+        except:
+            raise EliotParseError(message_dict, sys.exc_info())
+    for task in parser.incomplete_tasks():
+        yield task
 
 
 __all__ = ['tasks_from_iterable']

--- a/eliottree/_parse.py
+++ b/eliottree/_parse.py
@@ -1,0 +1,17 @@
+from eliot._parse import Parser
+
+
+def tasks_from_iterable(iterable):
+    """
+    Parse an iterable of Eliot message dictionaries into tasks.
+
+    :type iterable: ``Iterable[Dict]``
+    :param iterable: Iterable of serialized Eliot message dictionaries.
+    :rtype: ``Iterable``
+    :return: Iterable of parsed Eliot tasks, suitable for use with
+    `eliottree.render_tasks`.
+    """
+    return Parser.parse_stream(iterable)
+
+
+__all__ = ['tasks_from_iterable']

--- a/eliottree/_render.py
+++ b/eliottree/_render.py
@@ -1,0 +1,206 @@
+from functools import partial
+
+from eliot._action import WrittenAction
+from eliot._message import WrittenMessage
+from eliot._parse import Task
+from termcolor import colored
+from toolz import compose, identity
+from tree_format import format_tree
+
+from eliottree import format
+
+
+RIGHT_DOUBLE_ARROW = u'\u21d2'
+
+DEFAULT_IGNORED_KEYS = set([
+    u'action_status', u'action_type', u'task_level', u'task_uuid',
+    u'message_type'])
+
+
+class Color(object):
+    def __init__(self, color, attrs=[]):
+        self.color = color
+        self.attrs = attrs
+
+    def __get__(self, instance, owner):
+        return lambda text: instance.colored(
+            text, self.color, attrs=self.attrs)
+
+
+class COLORS(object):
+    root = Color('white', ['bold'])
+    parent = Color('magenta')
+    success = Color('green')
+    failure = Color('red')
+    prop = Color('blue')
+
+    def __init__(self, colored):
+        self.colored = colored
+
+
+def _no_color(text, *a, **kw):
+    """
+    Colorizer that does not colorize.
+    """
+    return text
+
+
+def _default_value_formatter(human_readable, field_limit, encoding='utf-8'):
+    """
+    Create a value formatter based on several user-specified options.
+    """
+    fields = {}
+    if human_readable:
+        fields = {
+            u'timestamp': format.timestamp(),
+        }
+    return compose(
+        # We want tree-format to handle newlines.
+        partial(format.escape_control_characters, overrides={0x0a: u'\n'}),
+        partial(format.truncate_value,
+                field_limit) if field_limit else identity,
+        format.some(
+            format.fields(fields),
+            format.text(),
+            format.binary(encoding),
+            format.anything(encoding)))
+
+
+def message_name(colors, message):
+    """
+    Derive the name for a message.
+
+    If the message is an action type then the ``action_type`` field is used in
+    conjunction with ``task_level`` and ``action_status``. If the message is a
+    message type then the ``message_type`` and ``task_level`` fields are used,
+    otherwise no name will be derived.
+    """
+    if message is not None:
+        if u'action_type' in message.contents:
+            action_type = format.escape_control_characters(
+                message.contents.action_type)
+            action_status = message.contents.action_status
+            status_color = identity
+            if action_status == u'succeeded':
+                status_color = colors.success
+            elif action_status == u'failed':
+                status_color = colors.failure
+            return u'{}{} {} {}'.format(
+                colors.parent(action_type),
+                message.task_level.to_string(),
+                RIGHT_DOUBLE_ARROW,
+                status_color(message.contents.action_status))
+        elif u'message_type' in message.contents:
+            message_type = format.escape_control_characters(
+                message.contents.message_type)
+            return u'{}{}'.format(
+                colors.parent(message_type),
+                message.task_level.to_string())
+    return u'<unnamed>'
+
+
+def format_node(format_value, colors, node):
+    """
+    Format a node for display purposes.
+
+    Different representations exist for the various types of node:
+        - `eliot._parse.Task`: A task UUID.
+        - `eliot._action.WrittenAction`: An action's type, level and status.
+        - `eliot._message.WrittenMessage`: A message's type and level.
+        - ``tuple``: A field name and value.
+    """
+    if isinstance(node, Task):
+        return u'{}'.format(
+            colors.root(format.escape_control_characters(node.root().task_uuid)))
+    elif isinstance(node, WrittenAction):
+        return message_name(colors, node.start_message)
+    elif isinstance(node, WrittenMessage):
+        return message_name(colors, node)
+    elif isinstance(node, tuple):
+        key, value = node
+        if isinstance(value, (dict, list)):
+            value = u''
+        else:
+            value = format_value(value, key)
+        return u'{}: {}'.format(
+            colors.prop(format.escape_control_characters(key)),
+            value)
+    raise NotImplementedError()
+
+
+def message_fields(message, ignored_fields):
+    """
+    Sorted fields for a `WrittenMessage`.
+    """
+    def _items():
+        try:
+            yield u'timestamp', message.timestamp
+        except KeyError:
+            pass
+        for key, value in message.contents.items():
+            if key not in ignored_fields:
+                yield key, value
+    return sorted(_items()) if message else []
+
+
+def get_children(ignored_fields, node):
+    """
+    Retrieve the child nodes for a node.
+
+    The various types of node have different concepts of children:
+        - `eliot._parse.Task`: The root ``WrittenAction``.
+        - `eliot._action.WrittenAction`: The start message fields, child
+          ``WrittenAction`` or ``WrittenMessage``s, and end ``WrittenMessage``.
+        - `eliot._message.WrittenMessage`: Message fields.
+        - ``tuple``: Contained values for `dict` and `list` types.
+    """
+    if isinstance(node, Task):
+        return [node.root()]
+    elif isinstance(node, WrittenAction):
+        return filter(None,
+                      message_fields(node.start_message, ignored_fields) +
+                      list(node.children) +
+                      [node.end_message])
+    elif isinstance(node, WrittenMessage):
+        return message_fields(node, ignored_fields)
+    elif isinstance(node, tuple):
+        value = node[1]
+        if isinstance(value, dict):
+            return sorted(value.items())
+        elif isinstance(value, list):
+            return enumerate(value)
+    return []
+
+
+def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
+                 human_readable=False, colorize=False):
+    """
+    Render Eliot tasks as an ASCII tree.
+
+    :type write: ``Callable[[text_type], None]``
+    :param write: Callable used to write the output.
+    :type tasks: ``Iterable``
+    :param tasks: Iterable of parsed Eliot tasks, as returned by
+    `eliottree.tasks_from_iterable`.
+    :param int field_limit: Length at which to begin truncating, ``0`` means no
+    truncation.
+    :type ignored_fields: ``Set[text_type]``
+    :param ignored_fields: Set of field names to ignore, defaults to ignoring
+    most Eliot metadata.
+    :param bool human_readable: Render field values as human-readable?
+    :param bool colorize: Colorized the output?
+    """
+    if ignored_fields is None:
+        ignored_fields = DEFAULT_IGNORED_KEYS
+    _format_node = partial(
+        format_node,
+        _default_value_formatter(human_readable=human_readable,
+                                 field_limit=field_limit),
+        COLORS(colored if colorize else _no_color))
+    _get_children = partial(get_children, ignored_fields)
+    for task in tasks:
+        write(format_tree(task, _format_node, _get_children))
+        write(u'\n')
+
+
+__all__ = ['render_tasks']

--- a/eliottree/_render.py
+++ b/eliottree/_render.py
@@ -111,7 +111,8 @@ def format_node(format_value, colors, node):
     """
     if isinstance(node, Task):
         return u'{}'.format(
-            colors.root(format.escape_control_characters(node.root().task_uuid)))
+            colors.root(
+                format.escape_control_characters(node.root().task_uuid)))
     elif isinstance(node, WrittenAction):
         return message_name(colors, node.start_message)
     elif isinstance(node, WrittenMessage):

--- a/eliottree/filter.py
+++ b/eliottree/filter.py
@@ -18,7 +18,7 @@ def filter_by_uuid(task_uuid):
     """
     Produce a function for filtering tasks by their UUID.
     """
-    return filter_by_jmespath('task_uuid == `{}`'.format(task_uuid))
+    return filter_by_jmespath(u'task_uuid == `{}`'.format(task_uuid))
 
 
 def _parse_timestamp(timestamp):
@@ -34,7 +34,7 @@ def filter_by_start_date(start_date):
     date and time.
     """
     def _filter(task):
-        return _parse_timestamp(task['timestamp']) >= start_date
+        return _parse_timestamp(task[u'timestamp']) >= start_date
     return _filter
 
 
@@ -44,7 +44,7 @@ def filter_by_end_date(end_date):
     and time.
     """
     def _filter(task):
-        return _parse_timestamp(task['timestamp']) < end_date
+        return _parse_timestamp(task[u'timestamp']) < end_date
     return _filter
 
 

--- a/eliottree/format.py
+++ b/eliottree/format.py
@@ -72,5 +72,5 @@ def truncate_value(limit, value):
     values = value.split(u'\n')
     value = values[0]
     if len(value) > limit or len(values) > 1:
-        return u'{} [...]'.format(value[:limit])
+        return u'{}\u2026'.format(value[:limit])
     return value

--- a/eliottree/format.py
+++ b/eliottree/format.py
@@ -1,6 +1,33 @@
 from datetime import datetime
 
-from six import binary_type, text_type
+from six import binary_type, text_type, unichr
+from toolz import merge
+
+
+_control_equivalents = dict((i, unichr(0x2400 + i)) for i in range(0x20))
+_control_equivalents[0x7f] = u'\u2421'
+
+
+def escape_control_characters(s, overrides={}):
+    """
+    Replace terminal control characters with their Unicode control character
+    equivalent.
+    """
+    return text_type(s).translate(merge(_control_equivalents, overrides))
+
+
+def some(*fs):
+    """
+    Create a function that returns the first non-``None`` result of applying
+    the arguments to each ``fs``.
+    """
+    def _some(*a, **kw):
+        for f in fs:
+            result = f(*a, **kw)
+            if result is not None:
+                return result
+        return None
+    return _some
 
 
 def binary(encoding):
@@ -74,3 +101,8 @@ def truncate_value(limit, value):
     if len(value) > limit or len(values) > 1:
         return u'{}\u2026'.format(value[:limit])
     return value
+
+
+__all__ = [
+    'escape_control_characters', 'some', 'binary', 'text', 'fields',
+    'timestamp', 'anything', 'truncate_value']

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -338,10 +338,11 @@ def get_children(ignored_fields, node):
     elif isinstance(node, WrittenMessage):
         return message_fields(node, ignored_fields)
     elif isinstance(node, tuple):
-        if isinstance(node[1], dict):
-            return sorted(node[1].items())
-        elif isinstance(node[1], list):
-            return enumerate(node[1])
+        value = node[1]
+        if isinstance(value, dict):
+            return sorted(value.items())
+        elif isinstance(value, list):
+            return enumerate(value)
     return []
 
 

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -1,73 +1,13 @@
-from functools import partial, wraps
+from functools import wraps
 from warnings import warn
 
-from eliot._action import WrittenAction
-from eliot._message import WrittenMessage
-from eliot._parse import Task
-from six import text_type, unichr
+from six import text_type
 from termcolor import colored
-from toolz import compose, identity, merge
 from tree_format import format_tree
 
-from eliottree import format
-
-
-DEFAULT_IGNORED_KEYS = set([
-    u'action_status', u'action_type', u'task_level', u'task_uuid',
-    u'message_type'])
-
-
-_control_equivalents = dict((i, unichr(0x2400 + i)) for i in range(0x20))
-_control_equivalents[0x7f] = u'\u2421'
-
-
-def _escape_control_characters(s, overrides={}):
-    """
-    Escape terminal control characters.
-    """
-    return text_type(s).translate(merge(_control_equivalents, overrides))
-
-
-def _no_color(text, *a, **kw):
-    """
-    Colorizer that does not colorize.
-    """
-    return text
-
-
-def some(*fs):
-    """
-    Create a function that returns the first non-``None`` result of applying
-    the arguments to each ``fs``.
-    """
-    def _some(*a, **kw):
-        for f in fs:
-            result = f(*a, **kw)
-            if result is not None:
-                return result
-        return None
-    return _some
-
-
-def _default_value_formatter(human_readable, field_limit, encoding='utf-8'):
-    """
-    Create a value formatter based on several user-specified options.
-    """
-    fields = {}
-    if human_readable:
-        fields = {
-            u'timestamp': format.timestamp(),
-        }
-    return compose(
-        # We want tree-format to handle newlines.
-        partial(_escape_control_characters, overrides={0x0a: u'\n'}),
-        partial(format.truncate_value,
-                field_limit) if field_limit else identity,
-        some(
-            format.fields(fields),
-            format.text(),
-            format.binary(encoding),
-            format.anything(encoding)))
+from eliottree._render import (
+    COLORS, DEFAULT_IGNORED_KEYS, _default_value_formatter, _no_color)
+from eliottree.format import escape_control_characters
 
 
 def render_task_nodes_unicode(write, nodes, field_limit,
@@ -133,36 +73,15 @@ def render_task_nodes(write, nodes, field_limit,
         colorize=colorize)
 
 
-class Color(object):
-    def __init__(self, color, attrs=[]):
-        self.color = color
-        self.attrs = attrs
-
-    def __get__(self, instance, owner):
-        return lambda text: instance.colored(
-            text, self.color, attrs=self.attrs)
-
-
-class COLORS(object):
-    root = Color('white', ['bold'])
-    parent = Color('magenta', [])
-    success = Color('green')
-    failure = Color('red')
-    prop = Color('blue')
-
-    def __init__(self, colored):
-        self.colored = colored
-
-
 def get_name_factory(colors):
     """
     Create a ``get_name`` function for use with `format_tree`.
     """
     def get_name(task):
         if isinstance(task, text_type):
-            return _escape_control_characters(task)
+            return escape_control_characters(task)
         elif isinstance(task, tuple):
-            name = _escape_control_characters(task[0])
+            name = escape_control_characters(task[0])
             if isinstance(task[1], dict):
                 return name
             elif isinstance(task[1], text_type):
@@ -174,7 +93,7 @@ def get_name_factory(colors):
             else:
                 return colors.root(name)
         else:
-            name = _escape_control_characters(task.name)
+            name = escape_control_characters(task.name)
             if task.success is True:
                 return colors.success(name)
             elif task.success is False:
@@ -237,144 +156,4 @@ def get_children_factory(ignored_task_keys, format_value):
     return get_children
 
 
-RIGHT_DOUBLE_ARROW = u'\u21d2'
-
-
-def message_name(colors, message):
-    """
-    Derive the name for a message.
-
-    If the message is an action type then the ``action_type`` field is used in
-    conjunction with ``task_level`` and ``action_status``. If the message is a
-    message type then the ``message_type`` and ``task_level`` fields are used,
-    otherwise no name will be derived.
-    """
-    if message is not None:
-        if u'action_type' in message.contents:
-            action_type = _escape_control_characters(
-                message.contents.action_type)
-            action_status = message.contents.action_status
-            status_color = identity
-            if action_status == u'succeeded':
-                status_color = colors.success
-            elif action_status == u'failed':
-                status_color = colors.failure
-            return u'{}{} {} {}'.format(
-                colors.parent(action_type),
-                message.task_level.to_string(),
-                RIGHT_DOUBLE_ARROW,
-                status_color(message.contents.action_status))
-        elif u'message_type' in message.contents:
-            message_type = _escape_control_characters(
-                message.contents.message_type)
-            return u'{}{}'.format(
-                colors.parent(message_type),
-                message.task_level.to_string())
-    return u'<unnamed>'
-
-
-def format_node(format_value, colors, node):
-    """
-    Format a node for display purposes.
-
-    Different representations exist for the various types of node:
-        - `eliot._parse.Task`: A task UUID.
-        - `eliot._action.WrittenAction`: An action's type, level and status.
-        - `eliot._message.WrittenMessage`: A message's type and level.
-        - ``tuple``: A field name and value.
-    """
-    if isinstance(node, Task):
-        return u'{}'.format(
-            colors.root(_escape_control_characters(node.root().task_uuid)))
-    elif isinstance(node, WrittenAction):
-        return message_name(colors, node.start_message)
-    elif isinstance(node, WrittenMessage):
-        return message_name(colors, node)
-    elif isinstance(node, tuple):
-        key, value = node
-        if isinstance(value, (dict, list)):
-            value = u''
-        else:
-            value = format_value(value, key)
-        return u'{}: {}'.format(
-            colors.prop(_escape_control_characters(key)),
-            value)
-    raise NotImplementedError()
-
-
-def message_fields(message, ignored_fields):
-    """
-    Sorted fields for a `WrittenMessage`.
-    """
-    def _items():
-        try:
-            yield u'timestamp', message.timestamp
-        except KeyError:
-            pass
-        for key, value in message.contents.items():
-            if key not in ignored_fields:
-                yield key, value
-    return sorted(_items()) if message else []
-
-
-def get_children(ignored_fields, node):
-    """
-    Retrieve the child nodes for a node.
-
-    The various types of node have different concepts of children:
-        - `eliot._parse.Task`: The root ``WrittenAction``.
-        - `eliot._action.WrittenAction`: The start message fields, child
-          ``WrittenAction`` or ``WrittenMessage``s, and end ``WrittenMessage``.
-        - `eliot._message.WrittenMessage`: Message fields.
-        - ``tuple``: Contained values for `dict` and `list` types.
-    """
-    if isinstance(node, Task):
-        return [node.root()]
-    elif isinstance(node, WrittenAction):
-        return filter(None,
-                      message_fields(node.start_message, ignored_fields) +
-                      list(node.children) +
-                      [node.end_message])
-    elif isinstance(node, WrittenMessage):
-        return message_fields(node, ignored_fields)
-    elif isinstance(node, tuple):
-        value = node[1]
-        if isinstance(value, dict):
-            return sorted(value.items())
-        elif isinstance(value, list):
-            return enumerate(value)
-    return []
-
-
-def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
-                 human_readable=False, colorize=False):
-    """
-    Render Eliot tasks as an ASCII tree.
-
-    :type write: ``Callable[[text_type], None]``
-    :param write: Callable used to write the output.
-    :type tasks: ``Iterable``
-    :param tasks: Iterable of parsed Eliot tasks, as returned by
-    `eliottree.tasks_from_iterable`.
-    :param int field_limit: Length at which to begin truncating, ``0`` means no
-    truncation.
-    :type ignored_fields: ``Set[text_type]``
-    :param ignored_fields: Set of field names to ignore, defaults to ignoring
-    most Eliot metadata.
-    :param bool human_readable: Render field values as human-readable?
-    :param bool colorize: Colorized the output?
-    """
-    if ignored_fields is None:
-        ignored_fields = DEFAULT_IGNORED_KEYS
-    _format_node = partial(
-        format_node,
-        _default_value_formatter(human_readable=human_readable,
-                                 field_limit=field_limit),
-        COLORS(colored if colorize else _no_color))
-    _get_children = partial(get_children, ignored_fields)
-    for task in tasks:
-        write(format_tree(task, _format_node, _get_children))
-        write(u'\n')
-
-
-__all__ = ['render_task_nodes', 'render_tasks']
+__all__ = ['render_task_nodes']

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -1,4 +1,5 @@
 from functools import partial, wraps
+from warnings import warn
 
 from six import text_type, unichr
 from termcolor import colored
@@ -118,6 +119,8 @@ def render_task_nodes(write, nodes, field_limit,
 
     :seealso: `render_task_nodes`
     """
+    warn('render_task_nodes is deprecated, use eliottree.render_tasks instead',
+         DeprecationWarning, 2)
     render_task_nodes_unicode(
         write=lambda value: write(value.encode(encoding)),
         nodes=nodes,

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -270,7 +270,7 @@ def message_name(colors, message):
             return u'{}{}'.format(
                 colors.parent(message_type),
                 message.task_level.to_string())
-    return '<unnamed>'
+    return u'<unnamed>'
 
 
 def format_node(format_value, colors, node):
@@ -307,7 +307,10 @@ def message_fields(message, ignored_fields):
     Sorted fields for a `WrittenMessage`.
     """
     def _items():
-        yield u'timestamp', message.timestamp
+        try:
+            yield u'timestamp', message.timestamp
+        except KeyError:
+            pass
         for key, value in message.contents.items():
             if key not in ignored_fields:
                 yield key, value
@@ -338,7 +341,6 @@ def get_children(ignored_fields, node):
         if isinstance(node[1], dict):
             return sorted(node[1].items())
         elif isinstance(node[1], list):
-            # XXX: test coverage
             return enumerate(node[1])
     return []
 

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -1,6 +1,9 @@
 from functools import partial, wraps
 from warnings import warn
 
+from eliot._action import WrittenAction
+from eliot._message import WrittenMessage
+from eliot._parse import Task
 from six import text_type, unichr
 from termcolor import colored
 from toolz import compose, identity, merge
@@ -142,6 +145,7 @@ class Color(object):
 
 class COLORS(object):
     root = Color('white', ['bold'])
+    parent = Color('magenta', [])
     success = Color('green')
     failure = Color('red')
     prop = Color('blue')
@@ -233,4 +237,141 @@ def get_children_factory(ignored_task_keys, format_value):
     return get_children
 
 
-__all__ = ['render_task_nodes', 'render_task_nodes_unicode']
+RIGHT_DOUBLE_ARROW = u'\u21d2'
+
+
+def message_name(colors, message):
+    """
+    Derive the name for a message.
+
+    If the message is an action type then the ``action_type`` field is used in
+    conjunction with ``task_level`` and ``action_status``. If the message is a
+    message type then the ``message_type`` and ``task_level`` fields are used,
+    otherwise no name will be derived.
+    """
+    if message is not None:
+        if u'action_type' in message.contents:
+            action_type = _escape_control_characters(
+                message.contents.action_type)
+            action_status = message.contents.action_status
+            status_color = identity
+            if action_status == u'succeeded':
+                status_color = colors.success
+            elif action_status == u'failed':
+                status_color = colors.failure
+            return u'{}{} {} {}'.format(
+                colors.parent(action_type),
+                message.task_level.to_string(),
+                RIGHT_DOUBLE_ARROW,
+                status_color(message.contents.action_status))
+        elif u'message_type' in message.contents:
+            message_type = _escape_control_characters(
+                message.contents.message_type)
+            return u'{}{}'.format(
+                colors.parent(message_type),
+                message.task_level.to_string())
+    return '<unnamed>'
+
+
+def format_node(format_value, colors, node):
+    """
+    Format a node for display purposes.
+
+    Different representations exist for the various types of node:
+        - `eliot._parse.Task`: A task UUID.
+        - `eliot._action.WrittenAction`: An action's type, level and status.
+        - `eliot._message.WrittenMessage`: A message's type and level.
+        - ``tuple``: A field name and value.
+    """
+    if isinstance(node, Task):
+        return u'{}'.format(
+            colors.root(_escape_control_characters(node.root().task_uuid)))
+    elif isinstance(node, WrittenAction):
+        return message_name(colors, node.start_message)
+    elif isinstance(node, WrittenMessage):
+        return message_name(colors, node)
+    elif isinstance(node, tuple):
+        key, value = node
+        if isinstance(value, (dict, list)):
+            value = u''
+        else:
+            value = format_value(value, key)
+        return u'{}: {}'.format(
+            colors.prop(_escape_control_characters(key)),
+            value)
+    raise NotImplementedError()
+
+
+def message_fields(message, ignored_fields):
+    """
+    Sorted fields for a `WrittenMessage`.
+    """
+    def _items():
+        yield u'timestamp', message.timestamp
+        for key, value in message.contents.items():
+            if key not in ignored_fields:
+                yield key, value
+    return sorted(_items()) if message else []
+
+
+def get_children(ignored_fields, node):
+    """
+    Retrieve the child nodes for a node.
+
+    The various types of node have different concepts of children:
+        - `eliot._parse.Task`: The root ``WrittenAction``.
+        - `eliot._action.WrittenAction`: The start message fields, child
+          ``WrittenAction`` or ``WrittenMessage``s, and end ``WrittenMessage``.
+        - `eliot._message.WrittenMessage`: Message fields.
+        - ``tuple``: Contained values for `dict` and `list` types.
+    """
+    if isinstance(node, Task):
+        return [node.root()]
+    elif isinstance(node, WrittenAction):
+        return filter(None,
+                      message_fields(node.start_message, ignored_fields) +
+                      list(node.children) +
+                      [node.end_message])
+    elif isinstance(node, WrittenMessage):
+        return message_fields(node, ignored_fields)
+    elif isinstance(node, tuple):
+        if isinstance(node[1], dict):
+            return sorted(node[1].items())
+        elif isinstance(node[1], list):
+            # XXX: test coverage
+            return enumerate(node[1])
+    return []
+
+
+def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
+                 human_readable=False, colorize=False):
+    """
+    Render Eliot tasks as an ASCII tree.
+
+    :type write: ``Callable[[text_type], None]``
+    :param write: Callable used to write the output.
+    :type tasks: ``Iterable``
+    :param tasks: Iterable of parsed Eliot tasks, as returned by
+    `eliottree.tasks_from_iterable`.
+    :param int field_limit: Length at which to begin truncating, ``0`` means no
+    truncation.
+    :type ignored_fields: ``Set[text_type]``
+    :param ignored_fields: Set of field names to ignore, defaults to ignoring
+    most Eliot metadata.
+    :param bool human_readable: Render field values as human-readable?
+    :param bool colorize: Colorized the output?
+    """
+    if ignored_fields is None:
+        ignored_fields = DEFAULT_IGNORED_KEYS
+    _format_node = partial(
+        format_node,
+        _default_value_formatter(human_readable=human_readable,
+                                 field_limit=field_limit),
+        COLORS(colored if colorize else _no_color))
+    _get_children = partial(get_children, ignored_fields)
+    for task in tasks:
+        write(format_tree(task, _format_node, _get_children))
+        write(u'\n')
+
+
+__all__ = ['render_task_nodes', 'render_tasks']

--- a/eliottree/test/tasks.py
+++ b/eliottree/test/tasks.py
@@ -11,7 +11,6 @@ message_task = {
     u"timestamp": 1425356700,
     u"message": u"Main loop terminated.",
     u"message_type": u"twisted:log",
-    u"action_type": u"nope",
     u"task_level": [1]}
 
 action_task = {
@@ -25,12 +24,19 @@ nested_action_task = {
     u"timestamp": 1425356900,
     u"action_status": u"started",
     u"task_uuid": u"f3a32bb3-ea6b-457c-aa99-08a3d0491ab4",
-    u"action_type": u"app:action:nested",
+    u"action_type": u"app:action:nest",
     u"task_level": [1, 1]}
 
 action_task_end = {
     u"timestamp": 1425356800,
     u"action_status": u"succeeded",
+    u"task_uuid": u"f3a32bb3-ea6b-457c-aa99-08a3d0491ab4",
+    u"action_type": u"app:action",
+    u"task_level": [2]}
+
+action_task_end_failed = {
+    u"timestamp": 1425356800,
+    u"action_status": u"failed",
     u"task_uuid": u"f3a32bb3-ea6b-457c-aa99-08a3d0491ab4",
     u"action_type": u"app:action",
     u"task_level": [2]}
@@ -43,6 +49,14 @@ dict_action_task = {
     u"task_level": [1],
     u"some_data": {u"a": 42}}
 
+list_action_task = {
+    u"timestamp": 1425356800,
+    u"action_status": u"started",
+    u"task_uuid": u"f3a32bb3-ea6b-457c-aa99-08a3d0491ab4",
+    u"action_type": u"app:action",
+    u"task_level": [1],
+    u"some_data": [u"a", u"b"]}
+
 multiline_action_task = {
     u"timestamp": 1425356800,
     u"action_status": u"started",
@@ -53,18 +67,18 @@ multiline_action_task = {
 
 janky_action_task = {
     u"timestamp": '1425356800\x1b(0',
-    u"action_status": u"started\x1b(0",
+    u"action_status": u"started",
     u"task_uuid": u"f3a32bb3-ea6b-457c-\x1b(0aa99-08a3d0491ab4",
     u"action_type": u"A\x1b(0",
     u"task_level": [1],
-    u"message": u"hello\x1b(0world",
+    u"mes\nsage": u"hello\x1b(0world",
     u"\x1b(0": "nope",
     u"\x1b(0": {u"\x1b(0": "nope"}}
 
 janky_message_task = {
     u"task_uuid": u"cdeb220d-7605-4d5f-\x1b(08341-1a170222e308",
-    u"error": False,
+    u"er\x1bror": False,
     u"timestamp": 1425356700,
-    u"message": u"Main loop\x1b(0terminated.",
+    u"mes\nsage": u"Main loop\x1b(0terminated.",
     u"message_type": u"M\x1b(0",
     u"task_level": [1]}

--- a/eliottree/test/test_cli.py
+++ b/eliottree/test/test_cli.py
@@ -11,7 +11,7 @@ from eliottree.test.tasks import message_task
 
 rendered_message_task = (
     u'cdeb220d-7605-4d5f-8341-1a170222e308\n'
-    u'\u2514\u2500\u2500 twisted:log@1\n'
+    u'\u2514\u2500\u2500 twisted:log/1\n'
     u'    \u251c\u2500\u2500 error: False\n'
     u'    \u251c\u2500\u2500 message: Main loop terminated.\n'
     u'    \u2514\u2500\u2500 timestamp: 2015-03-03 04:25:00\n\n'

--- a/eliottree/test/test_cli.py
+++ b/eliottree/test/test_cli.py
@@ -46,10 +46,10 @@ class EndToEndTests(TestCase):
         self.assertEqual(check_output(["eliot-tree", f.name]),
                          rendered_message_task)
 
-    def test_parsing_error(self):
+    def test_json_parse_error(self):
         """
         ``eliot-tree`` displays an error containing the file name, line number
-        and offending line in the event that parsing fails.
+        and offending line in the event that JSON parsing fails.
         """
         f = NamedTemporaryFile()
         f.write(dump_json_bytes(message_task) + b'\n')
@@ -60,27 +60,27 @@ class EndToEndTests(TestCase):
         lines = m.exception.output.splitlines()
         first_line = lines[0].decode('utf-8')
         second_line = lines[1].decode('utf-8')
-        self.assertIn('parsing error', first_line)
+        self.assertIn('JSON parse error', first_line)
         self.assertIn(f.name, first_line)
         self.assertIn('line 2', first_line)
         self.assertEqual('totally not valid JSON {', second_line)
 
-    def test_merging_error(self):
+    def test_eliot_parse_error(self):
         """
         ``eliot-tree`` displays an error containing the original file name,
-        line number and offending task in the event that merging fails.
+        line number and offending task in the event that parsing the message
+        dict fails.
         """
         f = NamedTemporaryFile()
-        f.write(dump_json_bytes(message_task) + b'\n')
         f.write(dump_json_bytes(missing_uuid_task) + b'\n')
         f.flush()
         with self.assertRaises(CalledProcessError) as m:
             check_output(['eliot-tree', f.name], stderr=STDOUT)
         lines = m.exception.output.splitlines()
         first_line = lines[0].decode('utf-8')
-        self.assertIn('merging error', first_line)
+        self.assertIn('Eliot message parse error', first_line)
         self.assertIn(f.name, first_line)
-        self.assertIn('line 2', first_line)
+        self.assertIn('line 1', first_line)
         formatted = pformat(missing_uuid_task).encode('utf-8').splitlines()
         self.assertEqual(
             lines[1:len(formatted) + 1],

--- a/eliottree/test/test_format.py
+++ b/eliottree/test/test_format.py
@@ -146,7 +146,7 @@ class TruncateTests(TestCase):
         """
         self.assertThat(
             format.truncate_value(10, u'abcdefghijklmnopqrstuvwxyz'),
-            ExactlyEquals(u'abcdefghij [...]'))
+            ExactlyEquals(u'abcdefghij\u2026'))
 
     def test_multiple_lines(self):
         """
@@ -155,4 +155,4 @@ class TruncateTests(TestCase):
         """
         self.assertThat(
             format.truncate_value(10, u'abc\ndef'),
-            ExactlyEquals(u'abc [...]'))
+            ExactlyEquals(u'abc\u2026'))

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -1,6 +1,7 @@
 from six import BytesIO, text_type
 from termcolor import colored
 from testtools import TestCase
+from testtools.matchers import Contains, IsDeprecated
 
 from eliottree import Tree, render_task_nodes
 from eliottree.render import COLORS, _default_value_formatter, get_name_factory
@@ -96,6 +97,14 @@ class RenderTaskNodesTests(TestCase):
     """
     Tests for ``eliottree.render.render_task_nodes``.
     """
+    def test_deprecated(self):
+        """
+        `render_task_nodes` is deprecated.
+        """
+        self.assertThat(
+            lambda: render_task_nodes(lambda: None, [], field_limit=0),
+            IsDeprecated(Contains('render_task_nodes is deprecated')))
+
     def test_tasks(self):
         """
         Render two tasks of sequential levels, by default most standard Eliot

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -8,9 +8,10 @@ from testtools.matchers import (
 
 from eliottree import (
     Tree, render_task_nodes, render_tasks, tasks_from_iterable)
-from eliottree.render import (
+from eliottree._render import (
     COLORS, RIGHT_DOUBLE_ARROW, _default_value_formatter, _no_color,
-    format_node, get_children, get_name_factory, message_fields, message_name)
+    format_node, get_children, message_fields, message_name)
+from eliottree.render import get_name_factory
 from eliottree.test.matchers import ExactlyEquals
 from eliottree.test.tasks import (
     action_task, action_task_end, action_task_end_failed, dict_action_task,

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -147,7 +147,6 @@ class RenderTaskNodesTests(TestCase):
         When no field limit is specified for task values, multiple lines are
         output for multiline tasks.
         """
-        self.skipTest('tree-format does not handle newlines well')
         fd = BytesIO()
         tree = Tree()
         tree.merge_tasks([multiline_action_task])
@@ -160,8 +159,8 @@ class RenderTaskNodesTests(TestCase):
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 app:action@1/started\n'
-                u'    \u251c\u2500\u2500 message: this is a\n'
-                u'        many line message\n'
+                u'    \u251c\u2500\u2500 message: this is a\u23ce\n'
+                u'    \u2502   many line message\n'
                 u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'
                 .encode('utf-8')))
 

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -181,7 +181,7 @@ class RenderTaskNodesTests(TestCase):
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 app:action@1/started\n'
-                u'    \u251c\u2500\u2500 message: this is a [...]\n'
+                u'    \u251c\u2500\u2500 message: this is a\u2026\n'
                 u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'
                 .encode('utf-8')))
 
@@ -202,8 +202,8 @@ class RenderTaskNodesTests(TestCase):
                 u'cdeb220d-7605-4d5f-8341-1a170222e308\n'
                 u'\u2514\u2500\u2500 twisted:log@1\n'
                 u'    \u251c\u2500\u2500 error: False\n'
-                u'    \u251c\u2500\u2500 message: Main  [...]\n'
-                u'    \u2514\u2500\u2500 timestamp: 14253 [...]\n\n'
+                u'    \u251c\u2500\u2500 message: Main \u2026\n'
+                u'    \u2514\u2500\u2500 timestamp: 14253\u2026\n\n'
                 .encode('utf-8')))
 
     def test_ignored_keys(self):

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -1,15 +1,21 @@
-from six import BytesIO, text_type
+from eliot._message import WrittenMessage
+from six import BytesIO, StringIO, text_type
 from termcolor import colored
-from testtools import TestCase
-from testtools.matchers import Contains, IsDeprecated
+from testtools import ExpectedException, TestCase
+from testtools.matchers import AfterPreprocessing as After
+from testtools.matchers import (
+    Contains, EndsWith, Equals, HasLength, IsDeprecated, StartsWith)
 
-from eliottree import Tree, render_task_nodes
-from eliottree.render import COLORS, _default_value_formatter, get_name_factory
+from eliottree import (
+    Tree, render_task_nodes, render_tasks, tasks_from_iterable)
+from eliottree.render import (
+    COLORS, RIGHT_DOUBLE_ARROW, _default_value_formatter, _no_color,
+    format_node, get_children, get_name_factory, message_fields, message_name)
 from eliottree.test.matchers import ExactlyEquals
 from eliottree.test.tasks import (
-    action_task, action_task_end, dict_action_task, janky_action_task,
-    janky_message_task, message_task, multiline_action_task,
-    nested_action_task)
+    action_task, action_task_end, action_task_end_failed, dict_action_task,
+    janky_action_task, janky_message_task, list_action_task, message_task,
+    multiline_action_task, nested_action_task)
 
 
 class DefaultValueFormatterTests(TestCase):
@@ -295,7 +301,7 @@ class RenderTaskNodesTests(TestCase):
                 u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 app:action@1/started\n'
                 u'    \u251c\u2500\u2500 timestamp: 1425356800\n'
-                u'    \u2514\u2500\u2500 app:action:nested@1,1/started\n'
+                u'    \u2514\u2500\u2500 app:action:nest@1,1/started\n'
                 u'        \u2514\u2500\u2500 timestamp: 1425356900\n\n'
                 .encode('utf-8')))
 
@@ -316,8 +322,8 @@ class RenderTaskNodesTests(TestCase):
             ExactlyEquals(
                 u'cdeb220d-7605-4d5f-\u241b(08341-1a170222e308\n'
                 u'\u2514\u2500\u2500 M\u241b(0@1\n'
-                u'    \u251c\u2500\u2500 error: False\n'
-                u'    \u251c\u2500\u2500 message: '
+                u'    \u251c\u2500\u2500 er\u241bror: False\n'
+                u'    \u251c\u2500\u2500 mes\u240asage: '
                 u'Main loop\u241b(0terminated.\n'
                 u'    \u2514\u2500\u2500 timestamp: 1425356700\n\n'
                 .encode('utf-8')))
@@ -338,10 +344,10 @@ class RenderTaskNodesTests(TestCase):
             fd.getvalue(),
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-\u241b(0aa99-08a3d0491ab4\n'
-                u'\u2514\u2500\u2500 A\u241b(0@1/started\u241b(0\n'
+                u'\u2514\u2500\u2500 A\u241b(0@1/started\n'
                 u'    \u251c\u2500\u2500 \u241b(0\n'
                 u'    \u2502   \u2514\u2500\u2500 \u241b(0: nope\n'
-                u'    \u251c\u2500\u2500 message: hello\u241b(0world\n'
+                u'    \u251c\u2500\u2500 mes\u240asage: hello\u241b(0world\n'
                 u'    \u2514\u2500\u2500 timestamp: 1425356800\u241b(0\n\n'
                 .encode('utf-8')))
 
@@ -462,3 +468,554 @@ class GetNameFactoryTests(TestCase):
         self.assertThat(
             get_name(node),
             ExactlyEquals(C.failure(node.name)))
+
+
+colors = COLORS(colored)
+no_colors = COLORS(_no_color)
+
+
+class MessageNameTests(TestCase):
+    """
+    Tests for `eliottree.render.message_name`.
+    """
+    def test_action_type(self):
+        """
+        Action types include their type name.
+        """
+        message = next(tasks_from_iterable([action_task])).root().start_message
+        self.assertThat(
+            message_name(colors, message),
+            StartsWith(colors.parent(message.contents.action_type)))
+
+    def test_action_task_level(self):
+        """
+        Action types include their task level.
+        """
+        message = next(tasks_from_iterable([action_task])).root().start_message
+        self.assertThat(
+            message_name(colors, message),
+            Contains(message.task_level.to_string()))
+
+    def test_action_status(self):
+        """
+        Action types include their status.
+        """
+        message = next(tasks_from_iterable([action_task])).root().start_message
+        self.assertThat(
+            message_name(colors, message),
+            EndsWith(u'started'))
+
+    def test_action_status_success(self):
+        """
+        Successful actions color their status.
+        """
+        message = next(tasks_from_iterable([
+            action_task, action_task_end,
+        ])).root().end_message
+        self.assertThat(
+            message_name(colors, message),
+            EndsWith(colors.success(u'succeeded')))
+
+    def test_action_status_failed(self):
+        """
+        Failed actions color their status.
+        """
+        message = next(tasks_from_iterable([
+            action_task, action_task_end_failed,
+        ])).root().end_message
+        self.assertThat(
+            message_name(colors, message),
+            EndsWith(colors.failure(u'failed')))
+
+    def test_message_type(self):
+        """
+        Message types include their type name.
+        """
+        message = WrittenMessage.from_dict(message_task)
+        self.assertThat(
+            message_name(colors, message),
+            StartsWith(colors.parent(message.contents.message_type)))
+
+    def test_message_task_level(self):
+        """
+        Message types include their task level.
+        """
+        message = WrittenMessage.from_dict(message_task)
+        self.assertThat(
+            message_name(colors, message),
+            Contains(message.task_level.to_string()))
+
+    def test_unknown(self):
+        """
+        None or messages with no identifiable information are rendered as
+        ``<unnamed>``.
+        """
+        self.assertThat(
+            message_name(colors, None),
+            ExactlyEquals(u'<unnamed>'))
+        message = WrittenMessage.from_dict({})
+        self.assertThat(
+            message_name(colors, message),
+            ExactlyEquals(u'<unnamed>'))
+
+
+class FormatNodeTests(TestCase):
+    """
+    Tests for `eliottree.render.format_node`.
+    """
+    def format_node(self, node, format_value=None, colors=no_colors):
+        if format_value is None:
+            def format_value(value, _):
+                return value
+        return format_node(format_value, colors, node)
+
+    def test_task(self):
+        """
+        `Task`'s UUID is rendered.
+        """
+        node = next(tasks_from_iterable([action_task]))
+        self.assertThat(
+            self.format_node(node),
+            ExactlyEquals(node.root().task_uuid))
+
+    def test_written_action(self):
+        """
+        `WrittenAction`'s start message is rendered.
+        """
+        node = next(tasks_from_iterable([action_task])).root()
+        self.assertThat(
+            self.format_node(node),
+            ExactlyEquals(u'{}{} {} {}'.format(
+                node.start_message.contents.action_type,
+                node.start_message.task_level.to_string(),
+                RIGHT_DOUBLE_ARROW,
+                node.start_message.contents.action_status)))
+
+    def test_tuple_list(self):
+        """
+        Tuples can be a key and list, in which case the value is not rendered
+        here.
+        """
+        node = (u'a\nb\x1bc', [u'x\n', u'y\x1b', u'z'])
+        self.assertThat(
+            self.format_node(node, colors=colors),
+            ExactlyEquals(u'{}: '.format(
+                colors.prop(u'a\u240ab\u241bc'))))
+
+    def test_tuple_dict(self):
+        """
+        Tuples can be a key and dict, in which case the value is not rendered
+        here.
+        """
+        node = (u'a\nb\x1bc', {u'x\n': u'y\x1b', u'z': u'zz'})
+        self.assertThat(
+            self.format_node(node, colors=colors),
+            ExactlyEquals(u'{}: '.format(
+                colors.prop(u'a\u240ab\u241bc'))))
+
+    def test_tuple_other(self):
+        """
+        Tuples can be a key and string, number, etc. rendered inline.
+        """
+        node = (u'a\nb\x1bc', u'hello')
+        self.assertThat(
+            self.format_node(node, colors=colors),
+            ExactlyEquals(u'{}: {}'.format(
+                colors.prop(u'a\u240ab\u241bc'),
+                u'hello')))
+
+        node = (u'a\nb\x1bc', 42)
+        self.assertThat(
+            self.format_node(node, colors=colors),
+            ExactlyEquals(u'{}: {}'.format(
+                colors.prop(u'a\u240ab\u241bc'),
+                42)))
+
+    def test_other(self):
+        """
+        Other types raise `NotImplementedError`.
+        """
+        node = object()
+        with ExpectedException(NotImplementedError):
+            self.format_node(node, colors=colors)
+
+
+class MessageFieldsTests(TestCase):
+    """
+    Tests for `eliottree.render.message_fields`.
+    """
+    def test_empty(self):
+        """
+        ``None`` or empty messages result in no fields.
+        """
+        self.assertThat(
+            message_fields(None, set()),
+            Equals([]))
+        message = WrittenMessage.from_dict({})
+        self.assertThat(
+            message_fields(message, set()),
+            Equals([]))
+
+    def test_fields(self):
+        """
+        Include all the message fields and the timestamp.
+        """
+        message = WrittenMessage.from_dict({u'a': 1})
+        self.assertThat(
+            message_fields(message, set()),
+            Equals([(u'a', 1)]))
+        message = WrittenMessage.from_dict({u'a': 1, u'timestamp': 12345678})
+        self.assertThat(
+            message_fields(message, set()),
+            Equals([(u'a', 1),
+                    (u'timestamp', 12345678)]))
+
+    def test_ignored_fields(self):
+        """
+        Ignore any specified fields.
+        """
+        message = WrittenMessage.from_dict({u'a': 1, u'b': 2})
+        self.assertThat(
+            message_fields(message, {u'b'}),
+            Equals([(u'a', 1)]))
+
+
+class GetChildrenTests(TestCase):
+    """
+    Tests for `eliottree.render.get_children`.
+    """
+    def test_task_action(self):
+        """
+        The root message is the only child of a `Task`.
+        """
+        node = next(tasks_from_iterable([action_task]))
+        self.assertThat(
+            get_children(set(), node),
+            Equals([node.root()]))
+        node = next(tasks_from_iterable([message_task]))
+        self.assertThat(
+            get_children(set(), node),
+            Equals([node.root()]))
+
+    def test_written_action_ignored_fields(self):
+        """
+        Action fields can be ignored.
+        """
+        task = dict(action_task)
+        task.update({u'c': u'3'})
+        node = next(tasks_from_iterable([task])).root()
+        start_message = node.start_message
+        self.assertThat(
+            list(get_children({u'c'}, node)),
+            Equals([
+                (u'action_status', start_message.contents.action_status),
+                (u'action_type', start_message.contents.action_type),
+                (u'timestamp', start_message.timestamp)]))
+
+    def test_written_action_start(self):
+        """
+        The children of a `WrittenAction` begin with the fields of the start
+        message.
+        """
+        node = next(tasks_from_iterable([
+            action_task, nested_action_task, action_task_end])).root()
+        start_message = node.start_message
+        self.assertThat(
+            list(get_children({u'foo'}, node))[:3],
+            Equals([
+                (u'action_status', start_message.contents.action_status),
+                (u'action_type', start_message.contents.action_type),
+                (u'timestamp', start_message.timestamp)]))
+
+    def test_written_action_children(self):
+        """
+        The children of a `WrittenAction` contain child actions/messages.
+        """
+        node = next(tasks_from_iterable([
+            action_task, nested_action_task, action_task_end])).root()
+        self.assertThat(
+            list(get_children({u'foo'}, node))[3],
+            Equals(node.children[0]))
+
+    def test_written_action_no_children(self):
+        """
+        The children of a `WrittenAction` does not contain any child
+        actions/messages if there aren't any.
+        """
+        node = next(tasks_from_iterable([action_task])).root()
+        self.assertThat(
+            list(get_children({u'foo'}, node)),
+            HasLength(3))
+
+    def test_written_action_no_end(self):
+        """
+        If the `WrittenAction` has no end message, it is excluded.
+        """
+        node = next(tasks_from_iterable([
+            action_task, nested_action_task])).root()
+        self.assertThat(
+            list(get_children({u'foo'}, node))[4:],
+            Equals([]))
+
+    def test_written_action_end(self):
+        """
+        The last child of a `WrittenAction` is the end message.
+        """
+        node = next(tasks_from_iterable([
+            action_task, nested_action_task, action_task_end])).root()
+        self.assertThat(
+            list(get_children({u'foo'}, node))[4:],
+            Equals([node.end_message]))
+
+    def test_written_message(self):
+        """
+        The fields of `WrittenMessage`\s are their children. Fields can also be
+        ignored.
+        """
+        node = WrittenMessage.from_dict({u'a': 1, u'b': 2, u'c': 3})
+        self.assertThat(
+            get_children({u'c'}, node),
+            Equals([
+                (u'a', 1),
+                (u'b', 2)]))
+
+    def test_tuple_dict(self):
+        """
+        The key/value pairs of dicts are their children.
+        """
+        node = (u'key', {u'a': 1, u'b': 2, u'c': 3})
+        self.assertThat(
+            # The ignores intentionally do nothing.
+            get_children({u'c'}, node),
+            Equals([
+                (u'a', 1),
+                (u'b', 2),
+                (u'c', 3)]))
+
+    def test_tuple_list(self):
+        """
+        The indexed items of lists are their children.
+        """
+        node = (u'key', [u'a', u'b', u'c'])
+        self.assertThat(
+            # The ignores intentionally do nothing.
+            get_children({2, u'c'}, node),
+            After(list,
+                  Equals([
+                      (0, u'a'),
+                      (1, u'b'),
+                      (2, u'c')])))
+
+    def test_other(self):
+        """
+        Other values are considered to have no children.
+        """
+        self.assertThat(get_children({}, None), Equals([]))
+        self.assertThat(get_children({}, 42), Equals([]))
+        self.assertThat(get_children({}, u'hello'), Equals([]))
+
+
+class RenderTasksTests(TestCase):
+    """
+    Tests for `eliottree.render.render_tasks`.
+    """
+    def render_tasks(self, iterable, **kw):
+        fd = StringIO()
+        tasks = tasks_from_iterable(iterable)
+        render_tasks(write=fd.write, tasks=tasks, **kw)
+        return fd.getvalue()
+
+    def test_tasks(self):
+        """
+        Render two tasks of sequential levels, by default most standard Eliot
+        task keys are ignored.
+        """
+        self.assertThat(
+            self.render_tasks([action_task, action_task_end]),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 timestamp: 1425356800\n'
+                u'    \u2514\u2500\u2500 app:action/2 \u21d2 succeeded\n'
+                u'        \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_tasks_human_readable(self):
+        """
+        Render two tasks of sequential levels, by default most standard Eliot
+        task keys are ignored, values are formatted to be human readable.
+        """
+        self.assertThat(
+            self.render_tasks([action_task, action_task_end],
+                              human_readable=True),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 timestamp: 2015-03-03 04:26:40\n'
+                u'    \u2514\u2500\u2500 app:action/2 \u21d2 succeeded\n'
+                u'        \u2514\u2500\u2500 timestamp: 2015-03-03 04:26:40\n'
+                u'\n'))
+
+    def test_multiline_field(self):
+        """
+        When no field limit is specified for task values, multiple lines are
+        output for multiline tasks.
+        """
+        fd = StringIO()
+        tasks = tasks_from_iterable([multiline_action_task])
+        render_tasks(
+            write=fd.write,
+            tasks=tasks)
+        self.assertThat(
+            fd.getvalue(),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 message: this is a\u23ce\n'
+                u'    \u2502   many line message\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_multiline_field_limit(self):
+        """
+        When a field limit is specified for task values, only the first of
+        multiple lines is output.
+        """
+        self.assertThat(
+            self.render_tasks([multiline_action_task],
+                              field_limit=1000),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 message: this is a\u2026\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_field_limit(self):
+        """
+        Truncate task values that are longer than the field_limit if specified.
+        """
+        self.assertThat(
+            self.render_tasks([message_task],
+                              field_limit=5),
+            ExactlyEquals(
+                u'cdeb220d-7605-4d5f-8341-1a170222e308\n'
+                u'\u2514\u2500\u2500 twisted:log/1\n'
+                u'    \u251c\u2500\u2500 error: False\n'
+                u'    \u251c\u2500\u2500 message: Main \u2026\n'
+                u'    \u2514\u2500\u2500 timestamp: 14253\u2026\n\n'))
+
+    def test_ignored_keys(self):
+        """
+        Task keys can be ignored.
+        """
+        self.assertThat(
+            self.render_tasks([action_task],
+                              ignored_fields={u'action_type'}),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 action_status: started\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_task_data(self):
+        """
+        Task data is rendered as tree elements.
+        """
+        self.assertThat(
+            self.render_tasks([message_task]),
+            ExactlyEquals(
+                u'cdeb220d-7605-4d5f-8341-1a170222e308\n'
+                u'\u2514\u2500\u2500 twisted:log/1\n'
+                u'    \u251c\u2500\u2500 error: False\n'
+                u'    \u251c\u2500\u2500 message: Main loop terminated.\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356700\n\n'))
+
+    def test_dict_data(self):
+        """
+        Task values that are ``dict``s are rendered as tree elements.
+        """
+        self.assertThat(
+            self.render_tasks([dict_action_task]),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 some_data: \n'
+                u'    \u2502   \u2514\u2500\u2500 a: 42\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_list_data(self):
+        """
+        Task values that are ``list``s are rendered as tree elements.
+        """
+        self.assertThat(
+            self.render_tasks([list_action_task]),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 some_data: \n'
+                u'    \u2502   \u251c\u2500\u2500 0: a\n'
+                u'    \u2502   \u2514\u2500\u2500 1: b\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\n\n'))
+
+    def test_nested(self):
+        """
+        Render nested tasks in a way that visually represents that nesting.
+        """
+        self.assertThat(
+            self.render_tasks([action_task, nested_action_task]),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 timestamp: 1425356800\n'
+                u'    \u2514\u2500\u2500 app:action:nest/1/1 \u21d2 started\n'
+                u'        \u2514\u2500\u2500 timestamp: 1425356900\n\n'))
+
+    def test_janky_message(self):
+        """
+        Task names, UUIDs, keys and values in messages all have control
+        characters escaped.
+        """
+        self.assertThat(
+            self.render_tasks([janky_message_task]),
+            ExactlyEquals(
+                u'cdeb220d-7605-4d5f-\u241b(08341-1a170222e308\n'
+                u'\u2514\u2500\u2500 M\u241b(0/1\n'
+                u'    \u251c\u2500\u2500 er\u241bror: False\n'
+                u'    \u251c\u2500\u2500 mes\u240asage: '
+                u'Main loop\u241b(0terminated.\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356700\n\n'))
+
+    def test_janky_action(self):
+        """
+        Task names, UUIDs, keys and values in actions all have control
+        characters escaped.
+        """
+        self.assertThat(
+            self.render_tasks([janky_action_task]),
+            ExactlyEquals(
+                u'f3a32bb3-ea6b-457c-\u241b(0aa99-08a3d0491ab4\n'
+                u'\u2514\u2500\u2500 A\u241b(0/1 \u21d2 started\n'
+                u'    \u251c\u2500\u2500 \u241b(0: \n'
+                u'    \u2502   \u2514\u2500\u2500 \u241b(0: nope\n'
+                u'    \u251c\u2500\u2500 mes\u240asage: hello\u241b(0world\n'
+                u'    \u2514\u2500\u2500 timestamp: 1425356800\u241b(0\n\n'))
+
+    def test_colorize(self):
+        """
+        Passing ``colorize=True`` will colorize the output.
+        """
+        self.assertThat(
+            self.render_tasks([action_task, action_task_end],
+                              colorize=True),
+            ExactlyEquals(
+                u'\n'.join([
+                    colors.root(u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4'),
+                    u'\u2514\u2500\u2500 {}/1 \u21d2 started'.format(
+                        colors.parent(u'app:action')),
+                    u'    \u251c\u2500\u2500 {}: {}'.format(
+                        colors.prop(u'timestamp'), u'1425356800'),
+                    u'    \u2514\u2500\u2500 {}/2 \u21d2 {}'.format(
+                        colors.parent(u'app:action'),
+                        colors.success(u'succeeded')),
+                    u'        \u2514\u2500\u2500 {}: {}'.format(
+                        colors.prop('timestamp'), u'1425356800'),
+                    u'\n',
+                ])))

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -63,7 +63,7 @@ class TaskNameTests(TestCase):
         """
         self.assertThat(
             task_name(nested_action_task),
-            Equals(u'app:action:nested@1,1/started'))
+            Equals(u'app:action:nest@1,1/started'))
 
 
 class TaskNodeTests(TestCase):

--- a/eliottree/test/test_tree.py
+++ b/eliottree/test/test_tree.py
@@ -1,5 +1,6 @@
 from testtools import TestCase
-from testtools.matchers import Equals, Is, MatchesListwise, raises
+from testtools.matchers import (
+    Contains, Equals, Is, IsDeprecated, MatchesListwise, raises)
 
 from eliottree.test.tasks import (
     action_task, action_task_end, message_task, nested_action_task,
@@ -153,6 +154,14 @@ class TreeTests(TestCase):
     """
     Tests for ``eliottree.tree.Tree``.
     """
+    def test_deprecated(self):
+        """
+        `Tree` is deprecated.
+        """
+        self.assertThat(
+            Tree,
+            IsDeprecated(Contains('Tree is deprecated')))
+
     def test_initial(self):
         """
         The initial state of a tree is always empty.

--- a/eliottree/tree.py
+++ b/eliottree/tree.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from six import text_type as unicode
 from six import PY2
 
@@ -127,6 +129,8 @@ class Tree(object):
         ``Tree.matching_nodes`` to obtain the tree nodes.
     """
     def __init__(self):
+        warn('Tree is deprecated, use eliottree.tasks_from_iterable instead',
+             DeprecationWarning, 2)
         self._nodes = {}
 
     def nodes(self, uuids=None):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "tree-format>=0.1.1",
         "termcolor>=1.1.0",
         "toolz>=0.8.2",
+        "eliot>=0.12.0",
     ],
     extras_require={
         "dev": ["pytest>=2.7.1", "testtools>=1.8.0"],


### PR DESCRIPTION
This has the added consequence of rewriting the renderer, introducing a second
API for parsing and rendering input. The old method has been deprecated.

Fixes #52.
Fixes #43.
Fixes #49.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/53)
<!-- Reviewable:end -->
