### PR TITLE
There is no point sorting the tasks by timestamp before rendering them.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,14 @@ was generated from:
    {"task_uuid": "89a56df5-d808-4a7c-8526-e603aae2e2f2", "action_type": "app:soap:service:success", "dump": "/home/user/dump_files/20150303/1425357071.51_Service_res.xml", "timestamp": 1425357071.513453, "action_status": "succeeded", "task_level": [2, 2]}
    {"status": 200, "task_uuid": "89a56df5-d808-4a7c-8526-e603aae2e2f2", "task_level": [3], "action_type": "app:soap:service:request", "timestamp": 1425357071.513992, "action_status": "succeeded"}
 
+Streaming
+---------
+
+It's possible to pipe data into eliot-tree, from a tailed log for example, and
+have it rendered incrementally. There is a caveat though: Trees are only
+rendered once an end message—a success or failure status—for the tree's root
+action appears in the data.
+
 Usage from Python
 -----------------
 

--- a/eliottree/_cli.py
+++ b/eliottree/_cli.py
@@ -68,9 +68,7 @@ def parse_messages(files=None, select=None, task_uuid=None, start=None,
         files = [text_reader(sys.stdin)]
     inventory = {}
     return inventory, tasks_from_iterable(
-        sorted(
-            filter(compose(*filter_funcs()), _parse(files, inventory)),
-            key=lambda task: task.get(u'timestamp')))
+        filter(compose(*filter_funcs()), _parse(files, inventory)))
 
 
 def display_tasks(tasks, color, ignored_fields, field_limit, human_readable):


### PR DESCRIPTION
Primarily because the order they were emitted will almost certainly be (or
approximate very closely) the order of the timestamps.

By not sorting the data before rendering it we can render the trees
incrementally, which is useful for streaming data to eliot-tree.

Fixes #11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/59)
<!-- Reviewable:end -->
