### PR TITLE
Bump tree-format dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "six>=1.9.0",
         "jmespath>=0.7.1",
         "iso8601>=0.1.10",
-        "tree-format>=0.1.1",
+        "tree-format>=0.1.2",
         "termcolor>=1.1.0",
         "toolz>=0.8.2",
         "eliot>=0.12.0",


### PR DESCRIPTION
The new version fixes an issue installing on Windows under some conditions. This
shouldn't be necessary but there's no reason not to be explicit.

Fixes #64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/65)
<!-- Reviewable:end -->
