### PR TITLE
Gracefully handle exceptions during node and value formatting.

### DIFF
--- a/eliottree/_cli.py
+++ b/eliottree/_cli.py
@@ -77,12 +77,14 @@ def display_tasks(tasks, color, ignored_fields, field_limit, human_readable):
     the task trees to stdout.
     """
     write = text_writer(sys.stdout).write
+    write_err = text_writer(sys.stderr).write
     if color == 'auto':
         colorize = sys.stdout.isatty()
     else:
         colorize = color == 'always'
     render_tasks(
         write=write,
+        write_err=write_err,
         tasks=tasks,
         ignored_fields=set(ignored_fields) or None,
         field_limit=field_limit,

--- a/eliottree/_render.py
+++ b/eliottree/_render.py
@@ -8,6 +8,7 @@ from toolz import compose, identity
 from tree_format import format_tree
 
 from eliottree import format
+from eliottree._util import eliot_ns, format_namespace, is_namespace
 
 
 RIGHT_DOUBLE_ARROW = u'\u21d2'
@@ -52,7 +53,7 @@ def _default_value_formatter(human_readable, field_limit, encoding='utf-8'):
     fields = {}
     if human_readable:
         fields = {
-            u'timestamp': format.timestamp(),
+            eliot_ns(u'timestamp'): format.timestamp(),
         }
     return compose(
         # We want tree-format to handle newlines.
@@ -126,6 +127,8 @@ def format_node(format_value, colors, node):
             value = u''
         else:
             value = format_value(value, key)
+        if is_namespace(key):
+            key = format_namespace(key)
         return u'{}: {}'.format(
             colors.prop(format.escape_control_characters(key)),
             value)
@@ -138,7 +141,7 @@ def message_fields(message, ignored_fields):
     """
     def _items():
         try:
-            yield u'timestamp', message.timestamp
+            yield eliot_ns('timestamp'), message.timestamp
         except KeyError:
             pass
         for key, value in message.contents.items():

--- a/eliottree/_render.py
+++ b/eliottree/_render.py
@@ -5,6 +5,7 @@ from functools import partial
 from eliot._action import WrittenAction
 from eliot._message import WrittenMessage
 from eliot._parse import Task
+from six import text_type
 from termcolor import colored
 from toolz import compose, excepts, identity
 from tree_format import format_tree
@@ -150,7 +151,11 @@ def message_fields(message, ignored_fields):
         for key, value in message.contents.items():
             if key not in ignored_fields:
                 yield key, value
-    return sorted(_items()) if message else []
+
+    def _sortkey(x):
+        k = x[0]
+        return format_namespace(k) if is_namespace(k) else k
+    return sorted(_items(), key=_sortkey) if message else []
 
 
 def get_children(ignored_fields, node):
@@ -245,7 +250,9 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
                     len(caught_exceptions))))
         for exc in caught_exceptions:
             for line in traceback.format_exception(*exc):
-                write_err(line.decode('utf-8'))
+                if not isinstance(line, text_type):
+                    line = line.decode('utf-8')
+                write_err(line)
             write_err(u'\n')
 
 

--- a/eliottree/_util.py
+++ b/eliottree/_util.py
@@ -1,0 +1,36 @@
+from collections import namedtuple
+
+
+namespace = namedtuple('namespace', ['prefix', 'name'])
+
+
+def namespaced(prefix):
+    """
+    Create a function that creates new names in the ``prefix`` namespace.
+
+    :rtype: Callable[[unicode], `namespace`]
+    """
+    return lambda name: namespace(prefix, name)
+
+
+def format_namespace(ns):
+    """
+    Format a `namespace`.
+
+    :rtype: unicode
+    """
+    if not is_namespace(ns):
+        raise TypeError('Expected namespace', ns)
+    return u'{}/{}'.format(ns.prefix, ns.name)
+
+
+def is_namespace(x):
+    """
+    Is this a `namespace` instance?
+
+    :rtype: bool
+    """
+    return isinstance(x, namespace)
+
+
+eliot_ns = namespaced(u'eliot')

--- a/eliottree/render.py
+++ b/eliottree/render.py
@@ -7,6 +7,7 @@ from tree_format import format_tree
 
 from eliottree._render import (
     COLORS, DEFAULT_IGNORED_KEYS, _default_value_formatter, _no_color)
+from eliottree._util import is_namespace, eliot_ns
 from eliottree.format import escape_control_characters
 
 
@@ -81,7 +82,10 @@ def get_name_factory(colors):
         if isinstance(task, text_type):
             return escape_control_characters(task)
         elif isinstance(task, tuple):
-            name = escape_control_characters(task[0])
+            key = task[0]
+            if is_namespace(key):
+                key = key.name
+            name = escape_control_characters(key)
             if isinstance(task[1], dict):
                 return name
             elif isinstance(task[1], text_type):
@@ -129,6 +133,8 @@ def get_children_factory(ignored_task_keys, format_value):
     def items_children(items):
         for key, value in sorted(items):
             if key not in ignored_task_keys:
+                if key == u'timestamp':
+                    key = eliot_ns(key)
                 if isinstance(value, dict):
                     yield key, value
                 else:
@@ -150,7 +156,10 @@ def get_children_factory(ignored_task_keys, format_value):
             return
         else:
             for child in items_children(task.task.items()):
-                yield child
+                if child[0] == u'timestamp':
+                    yield eliot_ns(child[0]), child[1]
+                else:
+                    yield child
             for child in task.children():
                 yield child
     return get_children

--- a/eliottree/test/test_cli.py
+++ b/eliottree/test/test_cli.py
@@ -13,9 +13,9 @@ from eliottree.test.tasks import message_task, missing_uuid_task
 rendered_message_task = (
     u'cdeb220d-7605-4d5f-8341-1a170222e308\n'
     u'\u2514\u2500\u2500 twisted:log/1\n'
+    u'    \u251c\u2500\u2500 eliot/timestamp: 2015-03-03 04:25:00\n'
     u'    \u251c\u2500\u2500 error: False\n'
-    u'    \u251c\u2500\u2500 message: Main loop terminated.\n'
-    u'    \u2514\u2500\u2500 timestamp: 2015-03-03 04:25:00\n\n'
+    u'    \u2514\u2500\u2500 message: Main loop terminated.\n\n'
 ).encode('utf-8')
 
 

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -849,7 +849,8 @@ class RenderTasksTests(TestCase):
     def test_format_node_failures(self):
         """
         Catch exceptions when formatting nodes and display a message without
-        interrupting the processing of tasks. List all caught exceptions to stderr.
+        interrupting the processing of tasks. List all caught exceptions to
+        stderr.
         """
         def bad_format_node(*a, **kw):
             raise ValueError('Nope')
@@ -904,9 +905,11 @@ class RenderTasksTests(TestCase):
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
-                u'    \u251c\u2500\u2500 eliot/timestamp: 2015-03-03 04:26:40\n'
+                u'    \u251c\u2500\u2500 eliot/timestamp: '
+                u'2015-03-03 04:26:40\n'
                 u'    \u2514\u2500\u2500 app:action/2 \u21d2 succeeded\n'
-                u'        \u2514\u2500\u2500 eliot/timestamp: 2015-03-03 04:26:40\n'
+                u'        \u2514\u2500\u2500 eliot/timestamp: '
+                u'2015-03-03 04:26:40\n'
                 u'\n'))
 
     def test_multiline_field(self):
@@ -1050,7 +1053,8 @@ class RenderTasksTests(TestCase):
                 u'    \u251c\u2500\u2500 eliot/timestamp: 1425356800\u241b(0\n'
                 u'    \u251c\u2500\u2500 \u241b(0: \n'
                 u'    \u2502   \u2514\u2500\u2500 \u241b(0: nope\n'
-                u'    \u2514\u2500\u2500 mes\u240asage: hello\u241b(0world\n\n'))
+                u'    \u2514\u2500\u2500 mes\u240asage: hello\u241b(0world\n\n'
+            ))
 
     def test_colorize(self):
         """

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -685,8 +685,8 @@ class MessageFieldsTests(TestCase):
         self.assertThat(
             message_fields(message, set()),
             Equals([
-                (eliot_ns(u'timestamp'), 12345678),
-                (u'a', 1)]))
+                (u'a', 1),
+                (eliot_ns(u'timestamp'), 12345678)]))
 
     def test_ignored_fields(self):
         """
@@ -726,9 +726,9 @@ class GetChildrenTests(TestCase):
         self.assertThat(
             list(get_children({u'c'}, node)),
             Equals([
-                (eliot_ns(u'timestamp'), start_message.timestamp),
                 (u'action_status', start_message.contents.action_status),
-                (u'action_type', start_message.contents.action_type)]))
+                (u'action_type', start_message.contents.action_type),
+                (eliot_ns(u'timestamp'), start_message.timestamp)]))
 
     def test_written_action_start(self):
         """
@@ -741,9 +741,9 @@ class GetChildrenTests(TestCase):
         self.assertThat(
             list(get_children({u'foo'}, node))[:3],
             Equals([
-                (eliot_ns(u'timestamp'), start_message.timestamp),
                 (u'action_status', start_message.contents.action_status),
-                (u'action_type', start_message.contents.action_type)]))
+                (u'action_type', start_message.contents.action_type),
+                (eliot_ns(u'timestamp'), start_message.timestamp)]))
 
     def test_written_action_children(self):
         """
@@ -969,8 +969,8 @@ class RenderTasksTests(TestCase):
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 app:action/1 \u21d2 started\n'
-                u'    \u251c\u2500\u2500 eliot/timestamp: 1425356800\n'
-                u'    \u2514\u2500\u2500 action_status: started\n\n'))
+                u'    \u251c\u2500\u2500 action_status: started\n'
+                u'    \u2514\u2500\u2500 eliot/timestamp: 1425356800\n\n'))
 
     def test_task_data(self):
         """
@@ -1050,9 +1050,9 @@ class RenderTasksTests(TestCase):
             ExactlyEquals(
                 u'f3a32bb3-ea6b-457c-\u241b(0aa99-08a3d0491ab4\n'
                 u'\u2514\u2500\u2500 A\u241b(0/1 \u21d2 started\n'
-                u'    \u251c\u2500\u2500 eliot/timestamp: 1425356800\u241b(0\n'
                 u'    \u251c\u2500\u2500 \u241b(0: \n'
                 u'    \u2502   \u2514\u2500\u2500 \u241b(0: nope\n'
+                u'    \u251c\u2500\u2500 eliot/timestamp: 1425356800\u241b(0\n'
                 u'    \u2514\u2500\u2500 mes\u240asage: hello\u241b(0world\n\n'
             ))
 

--- a/eliottree/test/test_render.py
+++ b/eliottree/test/test_render.py
@@ -97,10 +97,10 @@ class DefaultValueFormatterTests(TestCase):
         now = 1433631432
         self.assertThat(
             format_value(now, u'timestamp'),
-            ExactlyEquals(unicode(now)))
+            ExactlyEquals(text_type(now)))
         self.assertThat(
-            format_value(str(now), u'timestamp'),
-            ExactlyEquals(unicode(now)))
+            format_value(text_type(now), u'timestamp'),
+            ExactlyEquals(text_type(now)))
 
     def test_timestamp_field_not_human(self):
         """

--- a/eliottree/test/test_util.py
+++ b/eliottree/test/test_util.py
@@ -1,0 +1,64 @@
+from testtools import ExpectedException, TestCase
+from testtools.matchers import AfterPreprocessing as After
+from testtools.matchers import (
+    Equals, Is, MatchesAll, MatchesListwise, MatchesPredicate,
+    MatchesStructure)
+
+from eliottree._util import format_namespace, is_namespace, namespaced
+
+
+class NamespaceTests(TestCase):
+    """
+    Tests for `namespaced`, `format_namespace` and `is_namespace`.
+    """
+    def test_namespaced(self):
+        """
+        `namespaced` creates a function that when called produces a namespaced
+        name.
+        """
+        self.assertThat(
+            namespaced(u'foo'),
+            MatchesAll(
+                MatchesPredicate(callable, '%s is not callable'),
+                After(
+                    lambda f: f(u'bar'),
+                    MatchesAll(
+                        MatchesListwise([
+                            Equals(u'foo'),
+                            Equals(u'bar')]),
+                        MatchesStructure(
+                            prefix=Equals(u'foo'),
+                            name=Equals(u'bar'))))))
+
+    def test_format_not_namespace(self):
+        """
+        `format_namespace` raises `TypeError` if its argument is not a
+        namespaced name.
+        """
+        with ExpectedException(TypeError):
+            format_namespace(42)
+
+    def test_format_namespace(self):
+        """
+        `format_namespace` creates a text representation of a namespaced name.
+        """
+        self.assertThat(
+            format_namespace(namespaced(u'foo')(u'bar')),
+            Equals(u'foo/bar'))
+
+    def test_is_namespace(self):
+        """
+        `is_namespace` returns ``True`` only for namespaced names.
+        """
+        self.assertThat(
+            is_namespace(42),
+            Is(False))
+        self.assertThat(
+            is_namespace((u'foo', u'bar')),
+            Is(False))
+        self.assertThat(
+            is_namespace(namespaced(u'foo')),
+            Is(False))
+        self.assertThat(
+            is_namespace(namespaced(u'foo')(u'bar')),
+            Is(True))


### PR DESCRIPTION
A placeholder formatting value is emitted and all exceptions encountered are
written to stderr after processing tasks has completed.

Additionally, Eliot builtin fields are namespace prefixed now so that, for
example, user-defined `timestamp` fields don't trigger the formatting for the
Eliot timestamp field.

Fixes #67.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/68)
<!-- Reviewable:end -->
