### PR TITLE
Provide a "dark" and "light" theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,10 @@ Usage from the command-line
 
    $ eliot-tree
    usage: eliot-tree [-h] [-u UUID] [-i KEY] [--raw] [--local-timezone]
-                  [--color {always,auto,never}] [--ascii] [--no-color-tree]
-                  [-l LENGTH] [--select QUERY] [--start START] [--end END]
-                  [FILE [FILE ...]]
+                     [--color {always,auto,never}] [--ascii] [--no-color-tree]
+                     [--theme {auto,dark,light}] [-l LENGTH] [--select QUERY]
+                     [--start START] [--end END]
+                     [FILE [FILE ...]]
 
    Display an Eliot log as a tree of tasks.
 
@@ -103,6 +104,8 @@ Usage from the command-line
                            is a TTY.
      --ascii               Use ASCII for tree drawing characters.
      --no-color-tree       Do not color the tree lines.
+     --theme {auto,dark,light}
+                           Select a color theme to use.
      -l LENGTH, --field-limit LENGTH
                            Limit the length of field values to LENGTH or a
                            newline, whichever comes first. Use a length of 0 to

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -193,7 +193,7 @@ def track_exceptions(f, caught, default=None):
     return excepts(Exception, f, _catch)
 
 
-class ColorizedOptions():
+class ColorizedOptions(object):
     """
     `Options` for `format_tree` that colorizes sub-trees.
     """

--- a/src/eliottree/_theme.py
+++ b/src/eliottree/_theme.py
@@ -9,7 +9,7 @@ def color_factory(colored):
     return _color
 
 
-class Theme():
+class Theme(object):
     """
     Theme base class.
     """

--- a/src/eliottree/_theme.py
+++ b/src/eliottree/_theme.py
@@ -1,0 +1,93 @@
+def color_factory(colored):
+    """
+    Factory for making text color-wrappers.
+    """
+    def _color(color, attrs=[]):
+        def __color(text):
+            return colored(text, color, attrs=attrs)
+        return __color
+    return _color
+
+
+class Theme():
+    """
+    Theme base class.
+    """
+    __slots__ = [
+        'root',
+        'parent',
+        'success',
+        'failure',
+        'prop',
+        'error',
+        'timestamp',
+        'duration',
+        'tree_failed',
+        'tree_color0',
+        'tree_color1',
+        'tree_color2',
+    ]
+    def __init__(self, **theme):
+        super(Theme, self).__init__()
+        for k, v in theme.items():
+            setattr(self, k, v)
+
+
+class DarkBackgroundTheme(Theme):
+    """
+    Color theme for dark backgrounds.
+    """
+    def __init__(self, colored):
+        color = color_factory(colored)
+        super(DarkBackgroundTheme, self).__init__(
+            root=color('white', ['bold']),
+            parent=color('magenta'),
+            success=color('green'),
+            failure=color('red'),
+            prop=color('blue'),
+            error=color('red', ['bold']),
+            timestamp=color('white', ['dark']),
+            duration=color('blue', ['dark']),
+            tree_failed=color('red'),
+            tree_color0=color('white', ['dark']),
+            tree_color1=color('blue', ['dark']),
+            tree_color2=color('magenta', ['dark']),
+        )
+
+
+class LightBackgroundTheme(Theme):
+    """
+    Color theme for light backgrounds.
+    """
+    def __init__(self, colored):
+        color = color_factory(colored)
+        super(LightBackgroundTheme, self).__init__(
+            root=color('grey', ['bold']),
+            parent=color('magenta'),
+            success=color('green'),
+            failure=color('red'),
+            prop=color('blue'),
+            error=color('red', ['bold']),
+            timestamp=color('grey'),
+            duration=color('blue', ['dark']),
+            tree_failed=color('red'),
+            tree_color0=color('grey', ['dark']),
+            tree_color1=color('blue', ['dark']),
+            tree_color2=color('magenta', ['dark']),
+        )
+
+
+def _no_color(text, *a, **kw):
+    """
+    Colorizer that does not colorize.
+    """
+    return text
+
+
+def get_theme(dark_background, colored=None):
+    """
+    Create an appropriate theme.
+    """
+    if colored is None:
+        colored = _no_color
+    return DarkBackgroundTheme(colored) if dark_background else LightBackgroundTheme(colored)

--- a/src/eliottree/test/test_render.py
+++ b/src/eliottree/test/test_render.py
@@ -10,8 +10,9 @@ from testtools.matchers import (
 from eliottree import (
     render_tasks, tasks_from_iterable)
 from eliottree._render import (
-    COLORS, HOURGLASS, RIGHT_DOUBLE_ARROW, _default_value_formatter, _no_color,
-    format_node, get_children, message_fields, message_name)
+    HOURGLASS, RIGHT_DOUBLE_ARROW, _default_value_formatter, format_node,
+    get_children, message_fields, message_name)
+from eliottree._theme import get_theme
 from eliottree._util import eliot_ns
 from eliottree.test.matchers import ExactlyEquals
 from eliottree.test.tasks import (
@@ -131,8 +132,8 @@ class DefaultValueFormatterTests(TestCase):
             ExactlyEquals(text_type(now)))
 
 
-colors = COLORS(colored)
-no_colors = COLORS(_no_color)
+colors = get_theme(dark_background=True, colored=colored)
+no_colors = get_theme(dark_background=True, colored=None)
 
 
 def no_formatting(value, field_name=None):
@@ -704,11 +705,11 @@ class RenderTasksTests(TestCase):
 
     def test_colorize(self):
         """
-        Passing ``colorize=True`` will colorize the output.
+        Passing ``theme`` will colorize the output.
         """
         self.assertThat(
             self.render_tasks([action_task, action_task_end],
-                              colorize=True),
+                              theme=colors),
             ExactlyEquals(
                 u'\n'.join([
                     colors.root(u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4'),


### PR DESCRIPTION
Color rendering was refactored into a basic `Theme` class, of which there are two variants: `light` and `dark`. By default eliot-tree will try to detect the terminal background color (relying on `COLORFGBG` which a couple of terminals set) and fall back to the dark theme.

This can be overridden by passing `--theme={dark,light}` on the command line.

Fixes #78

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/89)
<!-- Reviewable:end -->
