### PR TITLE
Configuration system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,14 @@ have it rendered incrementally. There is a caveat though: Trees are only
 rendered once an end message—a success or failure status—for the tree's root
 action appears in the data.
 
-Usage from Python
------------------
+Command-line options
+--------------------
+
+Consult the output of `eliot-tree --help` to see a complete list of command-line
+options.
+
+Programmatic usage
+------------------
 
 .. code-block:: python
 
@@ -71,53 +77,43 @@ Usage from Python
 See :code:`help(render_tasks)` and :code:`help(tasks_from_iterable)` from a
 Python REPL for more information.
 
-Usage from the command-line
----------------------------
+Configuration
+-------------
 
-.. code-block::
+Command-line options may have custom defaults specified by way of a config file.
+The config file can be passed with the `--config` argument, or will be read from
+`~/.config/eliot-tree/config.json`. See `config.example.json`_ for an
+example.
 
-   $ eliot-tree
-   usage: eliot-tree [-h] [-u UUID] [-i KEY] [--raw] [--local-timezone]
-                     [--color {always,auto,never}] [--ascii] [--no-color-tree]
-                     [--theme {auto,dark,light}] [-l LENGTH] [--select QUERY]
-                     [--start START] [--end END]
-                     [FILE [FILE ...]]
+.. _config.example.json: https://github.com/jonathanj/eliottree/blob/master/config.example.json
 
-   Display an Eliot log as a tree of tasks.
+Theme overrides
+~~~~~~~~~~~~~~~
 
-   positional arguments:
-     FILE                  Files to process. Omit to read from stdin.
+Theme colors can be overridden via the `theme_overrides` key in the config file.
+The value of this key is itself a JSON object, each key is the name of a theme
+color and each value is a JSON list. This list should contain two values:
 
-   optional arguments:
-     -h, --help            show this help message and exit
-     -u UUID, --task-uuid UUID
-                           Select a specific task by UUID.
-     -i KEY, --ignore-task-key KEY
-                           Ignore a task key, use multiple times to ignore
-                           multiple keys. Defaults to ignoring most Eliot
-                           standard keys.
-     --raw                 Do not format some task values (such as UTC
-                           timestamps) as human-readable.
-     --local-timezone      Convert timestamps to the local timezone.
-     --color {always,auto,never}
-                           Color the output. Defaults based on whether the output
-                           is a TTY.
-     --ascii               Use ASCII for tree drawing characters.
-     --no-color-tree       Do not color the tree lines.
-     --theme {auto,dark,light}
-                           Select a color theme to use.
-     -l LENGTH, --field-limit LENGTH
-                           Limit the length of field values to LENGTH or a
-                           newline, whichever comes first. Use a length of 0 to
-                           output the complete value.
-     --select QUERY        Select tasks to be displayed based on a jmespath
-                           query, can be specified multiple times to mimic
-                           logical AND. If any child task is selected the entire
-                           top-level task is selected. See <http://jmespath.org/>
-     --start START         Select tasks whose timestamp occurs after (or on) an
-                           ISO8601 date.
-     --end END             Select tasks whose timestamp occurs before an ISO8601
-                           date.
+1. A string that is a known terminal color.
+2. An optional list of color attributes.
+
+For example, to override the `root` theme color to be bold magenta, and the
+`prop` theme color to be red:
+
+.. code-block:: json
+
+   {
+     "theme_overrides": {
+       "root": ["magenta", ["bold"]],
+       "prop": ["red"]
+     }
+   }
+
+See `_theme.py`_ for theme color names and the `termcolor`_ Python package for
+available color and attribute constants.
+
+.. _\_theme.py: https://github.com/jonathanj/eliottree/blob/master/src/eliottree/_theme.py
+.. _termcolor: https://pypi.org/project/termcolor/
 
 Contribute
 ----------

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,12 @@ The config file can be passed with the `--config` argument, or will be read from
 `~/.config/eliot-tree/config.json`. See `config.example.json`_ for an
 example.
 
+Use the `--show-default-config` command-line option to display the default
+configuration, suitable for redirecting to a file. Use the
+`--show-current-config` command-line option to display the current effective
+configuration.
+
+.. _\_cli.py: https://github.com/jonathanj/eliottree/blob/master/src/eliottree/_cli.py
 .. _config.example.json: https://github.com/jonathanj/eliottree/blob/master/config.example.json
 
 Theme overrides

--- a/README.rst
+++ b/README.rst
@@ -92,10 +92,12 @@ Theme overrides
 
 Theme colors can be overridden via the `theme_overrides` key in the config file.
 The value of this key is itself a JSON object, each key is the name of a theme
-color and each value is a JSON list. This list should contain two values:
+color and each value is a JSON list. This list should contain three values:
 
-1. A string that is a known terminal color.
-2. An optional list of color attributes.
+1. Foreground color, terminal color name or code; or `null` for the default color.
+2. Background color, terminal color name or code; or `null` for the default color.
+3. An optional array of color attribute names or codes; or `null` for the
+   default attribute.
 
 For example, to override the `root` theme color to be bold magenta, and the
 `prop` theme color to be red:
@@ -104,16 +106,16 @@ For example, to override the `root` theme color to be bold magenta, and the
 
    {
      "theme_overrides": {
-       "root": ["magenta", ["bold"]],
-       "prop": ["red"]
+       "root": ["magenta", null, ["bold"]],
+       "prop_key": ["red"]
      }
    }
 
-See `_theme.py`_ for theme color names and the `termcolor`_ Python package for
+See `_theme.py`_ for theme color names and the `colored`_ Python package for
 available color and attribute constants.
 
 .. _\_theme.py: https://github.com/jonathanj/eliottree/blob/master/src/eliottree/_theme.py
-.. _termcolor: https://pypi.org/project/termcolor/
+.. _colored: https://pypi.org/project/colored/
 
 Contribute
 ----------

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,11 @@
+{
+  "raw": true,
+  "color": "auto",
+  "ascii": true,
+  "colorize_tree": true,
+  "field_limit": 0,
+  "utc_timestamps": false,
+  "theme_overrides": {
+    "root": ["magenta", ["bold"]]
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'six>=1.13.0',
         'jmespath>=0.7.1',
         'iso8601>=0.1.10',
-        'termcolor>=1.1.0',
+        'colored>=1.4.2',
         'toolz>=0.8.2',
         'eliot>=1.6.0',
         'colorama>=0.4.3;platform_system=="Windows"',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'colored>=1.4.2',
         'toolz>=0.8.2',
         'eliot>=1.6.0',
-        'colorama>=0.4.3;platform_system=="Windows"',
         'win-unicode-console>=0.5;platform_system=="Windows"',
     ],
     extras_require={

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -5,7 +5,6 @@ import os
 import platform
 import sys
 from pprint import pformat
-from termcolor import colored
 
 import iso8601
 from six import PY3, binary_type, reraise
@@ -15,6 +14,7 @@ from toolz import compose
 from eliottree import (
     EliotParseError, JSONParseError, filter_by_end_date, filter_by_jmespath,
     filter_by_start_date, filter_by_uuid, render_tasks, tasks_from_iterable)
+from eliottree._color import colored
 from eliottree._theme import get_theme, apply_theme_overrides
 
 

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -82,17 +82,11 @@ def setup_platform(colorize):
     if platform.system() == 'Windows':
         # Initialise Unicode support for Windows terminals, even if they're not
         # using the Unicode codepage.
-        # N.B. This _must_ happen before `colorama` because win_unicode_console
-        # replaces stdin/stdout while colorama wraps them.
         import win_unicode_console  # noqa: E402
         import warnings  # noqa: E402
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=RuntimeWarning)
             win_unicode_console.enable()
-        if colorize:
-            # Initialise color support for Windows terminals.
-            import colorama  # noqa: E402
-            colorama.init()
 
 
 def display_tasks(tasks, color, colorize_tree, ascii, theme_name, ignored_fields,

--- a/src/eliottree/_color.py
+++ b/src/eliottree/_color.py
@@ -1,0 +1,45 @@
+import colored as _colored
+
+
+attr_codes = {
+    'bold': 1,
+    'dim': 2,
+    'underlined': 4,
+    'blink': 5,
+    'reverse': 7,
+    'hidden': 8,
+    'reset': 0,
+    'res_bold': 21,
+    'res_dim': 22,
+    'res_underlined': 24,
+    'res_blink': 25,
+    'res_reverse': 27,
+    'res_hidden': 28,
+}
+
+
+def colored(text, fg=None, bg=None, attrs=None):
+    """
+    Wrap text in terminal color codes.
+
+    Intended to mimic the API of `termcolor`.
+    """
+    if attrs is None:
+        attrs = []
+    return u'{}{}{}{}{}'.format(
+        _colored.fg(fg) if fg is not None else u'',
+        _colored.bg(bg) if bg is not None else u'',
+        text,
+        u''.join(_colored.attr(attr_codes.get(attr, attr)) for attr in attrs),
+        _colored.attr(0))
+
+
+def color_factory(colored):
+    """
+    Factory for making text color-wrappers.
+    """
+    def _color(fg, bg=None, attrs=[]):
+        def __color(text):
+            return colored(text, fg, bg, attrs=attrs)
+        return __color
+    return _color

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -79,12 +79,12 @@ def message_name(theme, format_value, message, end_message=None):
                 action_status = message.contents.action_status
             status_color = identity
             if action_status == u'succeeded':
-                status_color = theme.success
+                status_color = theme.status_success
             elif action_status == u'failed':
-                status_color = theme.failure
+                status_color = theme.status_failure
             return u'{}{} {} {} {}{}'.format(
                 theme.parent(action_type),
-                message.task_level.to_string(),
+                theme.task_level(message.task_level.to_string()),
                 RIGHT_DOUBLE_ARROW,
                 status_color(message.contents.action_status),
                 timestamp,
@@ -94,7 +94,7 @@ def message_name(theme, format_value, message, end_message=None):
                 message.contents.message_type)
             return u'{}{} {}'.format(
                 theme.parent(message_type),
-                message.task_level.to_string(),
+                theme.task_level(message.task_level.to_string()),
                 timestamp)
     return u'<unnamed>'
 
@@ -133,8 +133,8 @@ def format_node(format_value, theme, node):
         if is_namespace(key):
             key = format_namespace(key)
         return u'{}: {}'.format(
-            theme.prop(format.escape_control_characters(key)),
-            value)
+            theme.prop_key(format.escape_control_characters(key)),
+            theme.prop_value(text_type(value)))
     raise NotImplementedError()
 
 

--- a/src/eliottree/_theme.py
+++ b/src/eliottree/_theme.py
@@ -1,3 +1,34 @@
+NO_COLOR = (None,)
+DEFAULT_THEME = {
+    # Task root.
+    'root': NO_COLOR,
+    # Action / message node.
+    'parent': NO_COLOR,
+    # Action / message task level.
+    'task_level': NO_COLOR,
+    # Action success status.
+    'status_success': NO_COLOR,
+    # Action failure status.
+    'status_failure': NO_COLOR,
+    # Task timestamp.
+    'timestamp': NO_COLOR,
+    # Action / message property key.
+    'prop_key': NO_COLOR,
+    # Action / message property value.
+    'prop_value': NO_COLOR,
+    # Task duration.
+    'duration': NO_COLOR,
+    # Tree color for failed tasks.
+    'tree_failed': NO_COLOR,
+    # Cycled tree colors.
+    'tree_color0': NO_COLOR,
+    'tree_color1': NO_COLOR,
+    'tree_color2': NO_COLOR,
+    # Processing error.
+    'error': NO_COLOR,
+}
+
+
 def color_factory(colored):
     """
     Factory for making text color-wrappers.
@@ -13,24 +44,18 @@ class Theme(object):
     """
     Theme base class.
     """
-    __slots__ = [
-        'root',
-        'parent',
-        'success',
-        'failure',
-        'prop',
-        'error',
-        'timestamp',
-        'duration',
-        'tree_failed',
-        'tree_color0',
-        'tree_color1',
-        'tree_color2',
-    ]
-    def __init__(self, **theme):
+    __slots__ = DEFAULT_THEME.keys()
+
+    def __init__(self, color, **theme):
         super(Theme, self).__init__()
-        for k, v in theme.items():
-            setattr(self, k, v)
+        self.color = color
+        _theme = dict(DEFAULT_THEME)
+        _theme.update(theme)
+        for k, v in _theme.items():
+            if not isinstance(v, (tuple, list)):
+                raise TypeError(
+                    'Theme color must be a tuple or list of values', k, v)
+            setattr(self, k, color(*v))
 
 
 class DarkBackgroundTheme(Theme):
@@ -38,20 +63,20 @@ class DarkBackgroundTheme(Theme):
     Color theme for dark backgrounds.
     """
     def __init__(self, colored):
-        color = color_factory(colored)
         super(DarkBackgroundTheme, self).__init__(
-            root=color('white', ['bold']),
-            parent=color('magenta'),
-            success=color('green'),
-            failure=color('red'),
-            prop=color('blue'),
-            error=color('red', ['bold']),
-            timestamp=color('white', ['dark']),
-            duration=color('blue', ['dark']),
-            tree_failed=color('red'),
-            tree_color0=color('white', ['dark']),
-            tree_color1=color('blue', ['dark']),
-            tree_color2=color('magenta', ['dark']),
+            color=color_factory(colored),
+            root=('white', ['bold']),
+            parent=('magenta',),
+            status_success=('green',),
+            status_failure=('red',),
+            prop_key=('blue',),
+            error=('red', ['bold']),
+            timestamp=('white', ['dark']),
+            duration=('blue', ['dark']),
+            tree_failed=('red',),
+            tree_color0=('white', ['dark']),
+            tree_color1=('blue', ['dark']),
+            tree_color2=('magenta', ['dark']),
         )
 
 
@@ -60,20 +85,20 @@ class LightBackgroundTheme(Theme):
     Color theme for light backgrounds.
     """
     def __init__(self, colored):
-        color = color_factory(colored)
         super(LightBackgroundTheme, self).__init__(
-            root=color('grey', ['bold']),
-            parent=color('magenta'),
-            success=color('green'),
-            failure=color('red'),
-            prop=color('blue'),
-            error=color('red', ['bold']),
-            timestamp=color('grey'),
-            duration=color('blue', ['dark']),
-            tree_failed=color('red'),
-            tree_color0=color('grey', ['dark']),
-            tree_color1=color('blue', ['dark']),
-            tree_color2=color('magenta', ['dark']),
+            color=color_factory(colored),
+            root=('grey', ['bold']),
+            parent=('magenta',),
+            status_success=('green',),
+            status_failure=('red',),
+            prop_key=('blue',),
+            error=('red', ['bold']),
+            timestamp=('grey',),
+            duration=('blue', ['dark']),
+            tree_failed=('red',),
+            tree_color0=('grey', ['dark']),
+            tree_color1=('blue', ['dark']),
+            tree_color2=('magenta', ['dark']),
         )
 
 
@@ -91,3 +116,15 @@ def get_theme(dark_background, colored=None):
     if colored is None:
         colored = _no_color
     return DarkBackgroundTheme(colored) if dark_background else LightBackgroundTheme(colored)
+
+
+def apply_theme_overrides(theme, overrides):
+    """
+    Apply overrides to a theme.
+    """
+    if overrides is None:
+        return theme
+
+    for key, args in overrides.items():
+        setattr(theme, key, theme.color(*args))
+    return theme

--- a/src/eliottree/_theme.py
+++ b/src/eliottree/_theme.py
@@ -1,3 +1,6 @@
+from eliottree._color import color_factory
+
+
 NO_COLOR = (None,)
 DEFAULT_THEME = {
     # Task root.
@@ -29,17 +32,6 @@ DEFAULT_THEME = {
 }
 
 
-def color_factory(colored):
-    """
-    Factory for making text color-wrappers.
-    """
-    def _color(color, attrs=[]):
-        def __color(text):
-            return colored(text, color, attrs=attrs)
-        return __color
-    return _color
-
-
 class Theme(object):
     """
     Theme base class.
@@ -65,18 +57,18 @@ class DarkBackgroundTheme(Theme):
     def __init__(self, colored):
         super(DarkBackgroundTheme, self).__init__(
             color=color_factory(colored),
-            root=('white', ['bold']),
+            root=('white', None, ['bold']),
             parent=('magenta',),
             status_success=('green',),
             status_failure=('red',),
             prop_key=('blue',),
-            error=('red', ['bold']),
-            timestamp=('white', ['dark']),
-            duration=('blue', ['dark']),
+            error=('red', None, ['bold']),
+            timestamp=('white', None, ['dim']),
+            duration=('blue', None, ['dim']),
             tree_failed=('red',),
-            tree_color0=('white', ['dark']),
-            tree_color1=('blue', ['dark']),
-            tree_color2=('magenta', ['dark']),
+            tree_color0=('white', None, ['dim']),
+            tree_color1=('blue', None, ['dim']),
+            tree_color2=('magenta', None, ['dim']),
         )
 
 
@@ -87,18 +79,18 @@ class LightBackgroundTheme(Theme):
     def __init__(self, colored):
         super(LightBackgroundTheme, self).__init__(
             color=color_factory(colored),
-            root=('grey', ['bold']),
+            root=('dark_gray', None, ['bold']),
             parent=('magenta',),
             status_success=('green',),
             status_failure=('red',),
             prop_key=('blue',),
-            error=('red', ['bold']),
-            timestamp=('grey',),
-            duration=('blue', ['dark']),
+            error=('red', None, ['bold']),
+            timestamp=('dark_gray',),
+            duration=('blue', None, ['dim']),
             tree_failed=('red',),
-            tree_color0=('grey', ['dark']),
-            tree_color1=('blue', ['dark']),
-            tree_color2=('magenta', ['dark']),
+            tree_color0=('dark_gray', None, ['dim']),
+            tree_color1=('blue', None, ['dim']),
+            tree_color2=('magenta', None, ['dim']),
         )
 
 

--- a/src/eliottree/test/test_render.py
+++ b/src/eliottree/test/test_render.py
@@ -1,7 +1,6 @@
 import time
 from eliot.parse import WrittenMessage
 from six import StringIO, text_type
-from termcolor import colored
 from testtools import ExpectedException, TestCase
 from testtools.matchers import AfterPreprocessing as After
 from testtools.matchers import (
@@ -9,6 +8,7 @@ from testtools.matchers import (
 
 from eliottree import (
     render_tasks, tasks_from_iterable)
+from eliottree._color import colored
 from eliottree._render import (
     HOURGLASS, RIGHT_DOUBLE_ARROW, _default_value_formatter, format_node,
     get_children, message_fields, message_name)

--- a/src/eliottree/test/test_render.py
+++ b/src/eliottree/test/test_render.py
@@ -180,7 +180,7 @@ class MessageNameTests(TestCase):
         ])).root().end_message
         self.assertThat(
             message_name(colors, no_formatting, message),
-            Contains(colors.success(u'succeeded')))
+            Contains(colors.status_success(u'succeeded')))
 
     def test_action_status_failed(self):
         """
@@ -191,7 +191,7 @@ class MessageNameTests(TestCase):
         ])).root().end_message
         self.assertThat(
             message_name(colors, no_formatting, message),
-            Contains(colors.failure(u'failed')))
+            Contains(colors.status_failure(u'failed')))
 
     def test_message_type(self):
         """
@@ -268,8 +268,9 @@ class FormatNodeTests(TestCase):
         node = (u'a\nb\x1bc', [u'x\n', u'y\x1b', u'z'])
         self.assertThat(
             self.format_node(node, colors=colors),
-            ExactlyEquals(u'{}: '.format(
-                colors.prop(u'a\u240ab\u241bc'))))
+            ExactlyEquals(u'{}: {}'.format(
+                colors.prop_key(u'a\u240ab\u241bc'),
+                colors.prop_value(u''))))
 
     def test_tuple_dict(self):
         """
@@ -279,8 +280,9 @@ class FormatNodeTests(TestCase):
         node = (u'a\nb\x1bc', {u'x\n': u'y\x1b', u'z': u'zz'})
         self.assertThat(
             self.format_node(node, colors=colors),
-            ExactlyEquals(u'{}: '.format(
-                colors.prop(u'a\u240ab\u241bc'))))
+            ExactlyEquals(u'{}: {}'.format(
+                colors.prop_key(u'a\u240ab\u241bc'),
+                colors.prop_value(u''))))
 
     def test_tuple_other(self):
         """
@@ -290,15 +292,15 @@ class FormatNodeTests(TestCase):
         self.assertThat(
             self.format_node(node, colors=colors),
             ExactlyEquals(u'{}: {}'.format(
-                colors.prop(u'a\u240ab\u241bc'),
-                u'hello')))
+                colors.prop_key(u'a\u240ab\u241bc'),
+                colors.prop_value(u'hello'))))
 
         node = (u'a\nb\x1bc', 42)
         self.assertThat(
             self.format_node(node, colors=colors),
             ExactlyEquals(u'{}: {}'.format(
-                colors.prop(u'a\u240ab\u241bc'),
-                42)))
+                colors.prop_key(u'a\u240ab\u241bc'),
+                colors.prop_value(u'42'))))
 
     def test_other(self):
         """
@@ -713,15 +715,17 @@ class RenderTasksTests(TestCase):
             ExactlyEquals(
                 u'\n'.join([
                     colors.root(u'f3a32bb3-ea6b-457c-aa99-08a3d0491ab4'),
-                    u'\u2514\u2500\u2500 {}/1 \u21d2 {} {} {} {}'.format(
+                    u'\u2514\u2500\u2500 {}{} \u21d2 {} {} {} {}'.format(
                         colors.parent(u'app:action'),
-                        colors.success(u'started'),
+                        colors.task_level(u'/1'),
+                        colors.status_success(u'started'),
                         colors.timestamp(u'1425356800'),
                         HOURGLASS,
                         colors.duration(u'2')),
-                    u'    \u2514\u2500\u2500 {}/2 \u21d2 {} {}'.format(
+                    u'    \u2514\u2500\u2500 {}{} \u21d2 {} {}'.format(
                         colors.parent(u'app:action'),
-                        colors.success(u'succeeded'),
+                        colors.task_level(u'/2'),
+                        colors.status_success(u'succeeded'),
                         colors.timestamp(u'1425356802')),
                     u'\n',
                 ])))


### PR DESCRIPTION
Implement configuring eliottree's command-line defaults via a config file, with the added ability to override theme colors.

Fixes #88 
Refs #78

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/90)
<!-- Reviewable:end -->
