### PR TITLE
Release 19.0.1

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,6 +4,13 @@ eliot-tree changelog
 
 .. towncrier release notes start
 
+Eliottree 19.0.1 (2020-01-15)
+=============================
+
+The public API for `render_tasks` was broken unnecessarily in 19.0.0, this
+release replaces the `colorize` keyword argument and deprecates it instead.
+
+
 Eliottree 19.0.0 (2020-01-14)
 =============================
 

--- a/src/eliottree/__init__.py
+++ b/src/eliottree/__init__.py
@@ -4,12 +4,16 @@ from eliottree._render import render_tasks
 from eliottree.filter import (
     filter_by_end_date, filter_by_jmespath, filter_by_start_date,
     filter_by_uuid, combine_filters_and)
+from eliottree._theme import get_theme, apply_theme_overrides, Theme
+from eliottree._color import color_factory, colored
 
 
 __all__ = [
     'filter_by_jmespath', 'filter_by_uuid', 'filter_by_start_date',
     'filter_by_end_date', 'render_tasks', 'tasks_from_iterable',
     'EliotParseError', 'JSONParseError', 'combine_filters_and',
+    'get_theme', 'apply_theme_overrides', 'Theme', 'color_factory',
+    'colored',
 ]
 
 from ._version import get_versions  # noqa: E402

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+import warnings
 from functools import partial
 
 from eliot.parse import WrittenAction, WrittenMessage, Task
@@ -8,6 +9,7 @@ from toolz import compose, excepts, identity
 
 from eliottree import format
 from eliottree.tree_format import format_tree, Options, ASCII_OPTIONS
+from eliottree._color import colored
 from eliottree._util import eliot_ns, format_namespace, is_namespace
 from eliottree._theme import get_theme
 
@@ -214,7 +216,7 @@ class ColorizedOptions(object):
 
 
 def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
-                 human_readable=False, write_err=None,
+                 human_readable=False, colorize=None, write_err=None,
                  format_node=format_node, format_value=None,
                  utc_timestamps=True, colorize_tree=False, ascii=False,
                  theme=None):
@@ -232,7 +234,7 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
     :param ignored_fields: Set of field names to ignore, defaults to ignoring
     most Eliot metadata.
     :param bool human_readable: Render field values as human-readable?
-    :param bool colorize: Colorized the output?
+    :param bool colorize: Colorized the output? (Deprecated, use `theme`.)
     :type write_err: Callable[[`text_type`], None]
     :param write_err: Callable used to write errors.
     :param format_node: See `format_node`.
@@ -245,6 +247,13 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
     """
     if ignored_fields is None:
         ignored_fields = DEFAULT_IGNORED_KEYS
+    if colorize is not None:
+        warnings.warn(
+            'Passing `colorize` is deprecated, use `theme` instead.',
+            DeprecationWarning)
+        theme = get_theme(
+            dark_background=True,
+            colored=colored if colorize else None)
     if theme is None:
         theme = get_theme(dark_background=True)
     caught_exceptions = []


### PR DESCRIPTION
The public API for `render_tasks` was broken unnecessarily in 19.0.0, this
release replaces the `colorize` keyword argument and deprecates it instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/94)
<!-- Reviewable:end -->
