### PR TITLE
Be able to paginate the output of the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Vscode stuff
+.vscode/
+
+#pytest stuff
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 cover/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -54,8 +55,3 @@ docs/_build/
 # PyBuilder
 target/
 
-# Vscode stuff
-.vscode/
-
-#pytest stuff
-.pytest_cache/

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -288,7 +288,7 @@ def main():
                         help='''Show the current effective configuration.''')
     parser.add_argument('--chunk-size',
                         default=0,
-                        dest='chunk_size'
+                        dest='chunk_size',
                         type=int,
                         help='''Break the print output into chunks of size. 0 prints all lines''')
     args = parser.parse_args()

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -90,7 +90,7 @@ def setup_platform(colorize):
 
 
 def display_tasks(tasks, color, colorize_tree, ascii, theme_name, ignored_fields,
-                  field_limit, human_readable, utc_timestamps, theme_overrides):
+                  field_limit, human_readable, utc_timestamps, theme_overrides, chunk_size):
     """
     Render Eliot tasks, apply any command-line-specified behaviour and render
     the task trees to stdout.
@@ -123,7 +123,8 @@ def display_tasks(tasks, color, colorize_tree, ascii, theme_name, ignored_fields
         colorize_tree=colorize and colorize_tree,
         ascii=ascii,
         utc_timestamps=utc_timestamps,
-        theme=theme)
+        theme=theme,
+        chunk_size=chunk_size)
 
 
 def _decode_command_line(value, encoding='utf-8'):

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -90,7 +90,7 @@ def setup_platform(colorize):
 
 
 def display_tasks(tasks, color, colorize_tree, ascii, theme_name, ignored_fields,
-                  field_limit, human_readable, utc_timestamps, theme_overrides, chunk_size):
+                  field_limit, human_readable, utc_timestamps, theme_overrides, page_size):
     """
     Render Eliot tasks, apply any command-line-specified behaviour and render
     the task trees to stdout.
@@ -124,7 +124,7 @@ def display_tasks(tasks, color, colorize_tree, ascii, theme_name, ignored_fields
         ascii=ascii,
         utc_timestamps=utc_timestamps,
         theme=theme,
-        chunk_size=chunk_size)
+        page_size=page_size)
 
 
 def _decode_command_line(value, encoding='utf-8'):
@@ -286,11 +286,14 @@ def main():
                         dest='print_current_config',
                         action='store_true',
                         help='''Show the current effective configuration.''')
-    parser.add_argument('--chunk-size',
-                        default=0,
-                        dest='chunk_size',
+    parser.add_argument('--page-size',
+                        metavar="LINES"
                         type=int,
-                        help='''Break the print output into chunks of size. 0 prints all lines''')
+                        default=0,
+                        dest='page_size',
+                        help='''Paginate the display of the log file diplaying 
+                        this many new lines at each iteration. 
+                        If this is 0 then all lines will be output''')
     args = parser.parse_args()
     if args.print_default_config:
         print_namespace(parser.parse_args([]))
@@ -322,7 +325,7 @@ def main():
             human_readable=args.human_readable,
             utc_timestamps=args.utc_timestamps,
             theme_overrides=config.get('theme_overrides'),
-            chunk_size=args.chunk_size)
+            page_size=args.page_size)
     except JSONParseError as e:
         stderr.write(u'JSON parse error, file {}, line {}:\n{}\n\n'.format(
             e.file_name,

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -285,6 +285,11 @@ def main():
                         dest='print_current_config',
                         action='store_true',
                         help='''Show the current effective configuration.''')
+    parser.add_argument('--chunk-size',
+                        default=0,
+                        dest='chunk_size'
+                        type=int,
+                        help='''Break the print output into chunks of size. 0 prints all lines''')
     args = parser.parse_args()
     if args.print_default_config:
         print_namespace(parser.parse_args([]))
@@ -315,7 +320,8 @@ def main():
             field_limit=args.field_limit,
             human_readable=args.human_readable,
             utc_timestamps=args.utc_timestamps,
-            theme_overrides=config.get('theme_overrides'))
+            theme_overrides=config.get('theme_overrides')
+            chunk_size=args.chunk_size)
     except JSONParseError as e:
         stderr.write(u'JSON parse error, file {}, line {}:\n{}\n\n'.format(
             e.file_name,

--- a/src/eliottree/_cli.py
+++ b/src/eliottree/_cli.py
@@ -320,7 +320,7 @@ def main():
             field_limit=args.field_limit,
             human_readable=args.human_readable,
             utc_timestamps=args.utc_timestamps,
-            theme_overrides=config.get('theme_overrides')
+            theme_overrides=config.get('theme_overrides'),
             chunk_size=args.chunk_size)
     except JSONParseError as e:
         stderr.write(u'JSON parse error, file {}, line {}:\n{}\n\n'.format(

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -219,7 +219,7 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
                  human_readable=False, colorize=None, write_err=None,
                  format_node=format_node, format_value=None,
                  utc_timestamps=True, colorize_tree=False, ascii=False,
-                 theme=None, chunk_size=None):
+                 theme=None, chunk_size=0):
     """
     Render Eliot tasks as an ASCII tree.
 
@@ -285,10 +285,7 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
         return options
 
     for task in tasks:
-        if chunk_size is None:
-            write(format_tree(
-            task, _format_node, _get_children, make_options()))
-        else:
+        if chunk_size:
             chunks =  chunked_format_tree(task, _format_node, _get_children, make_options(), chunk_size)                      
             exit = False
             while True:
@@ -306,7 +303,9 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
                     break
             if exit:
                 break
-
+        else:
+            write(format_tree(
+            task, _format_node, _get_children, make_options()))
         write("\n")
 
     if write_err and caught_exceptions:

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -8,7 +8,7 @@ from six import text_type
 from toolz import compose, excepts, identity
 
 from eliottree import format
-from eliottree.tree_format import format_tree, Options, ASCII_OPTIONS
+from eliottree.tree_format import format_tree, Options, ASCII_OPTIONS, chunked_format_tree
 from eliottree._color import colored
 from eliottree._util import eliot_ns, format_namespace, is_namespace
 from eliottree._theme import get_theme
@@ -285,13 +285,11 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
         return options
 
     for task in tasks:
-        chunks = format_tree(
-            task, _format_node, _get_children, make_options(), chunk_size
-        )
         if chunk_size is None:
-            lines = next(chunks)
-            write(lines)
+            write(format_tree(
+            task, _format_node, _get_children, make_options()))
         else:
+            chunks =  chunked_format_tree(task, _format_node, _get_children, make_options(), chunk_size)                      
             exit = False
             while True:
                 try:

--- a/src/eliottree/_render.py
+++ b/src/eliottree/_render.py
@@ -8,7 +8,7 @@ from six import text_type
 from toolz import compose, excepts, identity
 
 from eliottree import format
-from eliottree.tree_format import format_tree, Options, ASCII_OPTIONS, chunked_format_tree
+from eliottree.tree_format import format_tree, Options, ASCII_OPTIONS, paged_format_tree
 from eliottree._color import colored
 from eliottree._util import eliot_ns, format_namespace, is_namespace
 from eliottree._theme import get_theme
@@ -219,7 +219,7 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
                  human_readable=False, colorize=None, write_err=None,
                  format_node=format_node, format_value=None,
                  utc_timestamps=True, colorize_tree=False, ascii=False,
-                 theme=None, chunk_size=0):
+                 theme=None, page_size=0):
     """
     Render Eliot tasks as an ASCII tree.
 
@@ -285,17 +285,17 @@ def render_tasks(write, tasks, field_limit=0, ignored_fields=None,
         return options
 
     for task in tasks:
-        if chunk_size:
-            chunks =  chunked_format_tree(task, _format_node, _get_children, make_options(), chunk_size)                      
+        if page_size:
+            pages =  paged_format_tree(task, _format_node, _get_children, make_options(), page_size)                      
             exit = False
             while True:
                 try:
-                    chunk = next(chunks)
+                    page = next(pages)
                 except StopIteration:
                     break
-                write(chunk)
+                write(page)
                 write("\n")
-                print("Press any key to continue or 'X' to exit or 'T' for next task:")
+                print("Press 'Enter' to continue or 'X' to exit or 'T' for next task:")
                 user_in = sys.stdin.readline().strip().lower()
                 exit = user_in == "x"
                 next_task = user_in == "t"

--- a/src/eliottree/tree_format/__init__.py
+++ b/src/eliottree/tree_format/__init__.py
@@ -17,6 +17,7 @@
 from ._text import (
     format_ascii_tree,
     format_tree,
+    chunked_format_tree,
     print_tree,
     Options,
     ASCII_OPTIONS,

--- a/src/eliottree/tree_format/__init__.py
+++ b/src/eliottree/tree_format/__init__.py
@@ -17,7 +17,7 @@
 from ._text import (
     format_ascii_tree,
     format_tree,
-    chunked_format_tree,
+    paged_format_tree,
     print_tree,
     Options,
     ASCII_OPTIONS,

--- a/src/eliottree/tree_format/_text.py
+++ b/src/eliottree/tree_format/_text.py
@@ -100,7 +100,7 @@ def _format_tree(node, format_node, get_children, options, prefix=u'', depth=0):
                                    depth=depth + 1):
             yield result
 
-def chunked_format_tree(node, format_node, get_children, options=None, chunk_size=None)->Generator[str]:
+def chunked_format_tree(node, format_node, get_children, options=None, chunk_size=0)->Generator[str]:
     lines = itertools.chain(
         [format_node(node)],
         _format_tree(node, format_node, get_children, options or Options()),
@@ -130,10 +130,10 @@ def format_tree(node, format_node, get_children, options=None):
 
 def format_ascii_tree(tree, format_node, get_children):
     """ Formats the tree using only ascii characters """
-    return next(format_tree(tree,
+    return format_tree(tree,
                        format_node,
                        get_children,
-                       ASCII_OPTIONS, None))
+                       ASCII_OPTIONS)
 
 
 def print_tree(*args, **kwargs):

--- a/src/eliottree/tree_format/_text.py
+++ b/src/eliottree/tree_format/_text.py
@@ -101,13 +101,23 @@ def _format_tree(node, format_node, get_children, options, prefix=u'', depth=0):
             yield result
 
 
-def format_tree(node, format_node, get_children, options=None):
+def format_tree(node, format_node, get_children, options=None, chunk_size=None):
     lines = itertools.chain(
         [format_node(node)],
         _format_tree(node, format_node, get_children, options or Options()),
-        [u''],
+        [u""],
     )
-    return u'\n'.join(lines)
+    if chunk_size is None or chunk_size<=0:
+        yield u"\n".join(lines)
+    else:
+        write_lines = u"\n".join((line for _, line in zip(range(chunk_size), lines)))
+        while True:
+            if not write_lines:
+                break
+            yield write_lines
+            write_lines = u"\n".join(
+                (line for _, line in zip(range(chunk_size), lines))
+            )
 
 
 def format_ascii_tree(tree, format_node, get_children):

--- a/src/eliottree/tree_format/_text.py
+++ b/src/eliottree/tree_format/_text.py
@@ -16,9 +16,9 @@
 
 
 """Library for formatting trees."""
-
+from __future__ import annotations
 import itertools
-
+from typing import Generator
 
 class Options(object):
     def __init__(self,
@@ -100,8 +100,7 @@ def _format_tree(node, format_node, get_children, options, prefix=u'', depth=0):
                                    depth=depth + 1):
             yield result
 
-
-def format_tree(node, format_node, get_children, options=None, chunk_size=None):
+def chunked_format_tree(node, format_node, get_children, options=None, chunk_size=None)->Generator[str]:
     lines = itertools.chain(
         [format_node(node)],
         _format_tree(node, format_node, get_children, options or Options()),
@@ -119,13 +118,22 @@ def format_tree(node, format_node, get_children, options=None, chunk_size=None):
                 (line for _, line in zip(range(chunk_size), lines))
             )
 
+def format_tree(node, format_node, get_children, options=None):
+    lines = itertools.chain(
+        [format_node(node)],
+        _format_tree(node, format_node, get_children, options or Options()),
+        [u""],
+    )
+    return u"\n".join(lines)
+
+
 
 def format_ascii_tree(tree, format_node, get_children):
     """ Formats the tree using only ascii characters """
-    return format_tree(tree,
+    return next(format_tree(tree,
                        format_node,
                        get_children,
-                       ASCII_OPTIONS)
+                       ASCII_OPTIONS, None))
 
 
 def print_tree(*args, **kwargs):

--- a/src/eliottree/tree_format/tests/test_text.py
+++ b/src/eliottree/tree_format/tests/test_text.py
@@ -22,8 +22,9 @@ from testtools import TestCase
 from testtools.matchers import DocTestMatches
 
 from .._text import (
-    format_tree, format_ascii_tree,
+    format_tree, format_ascii_tree, chunked_format_tree
 )
+from pprint import pprint as Print
 
 
 class TestFormatTree(TestCase):
@@ -152,6 +153,30 @@ class TestFormatTree(TestCase):
         |-- baz
         +-- qux
         '''), output)
+
+class TestChunkedFormatTree(TestCase):
+    def format_tree(self, tree):
+        return format_tree(tree, itemgetter(0), itemgetter(1))
+
+    def chunked_format_tree(self, tree, num_lines):
+        return chunked_format_tree(tree, itemgetter(0), itemgetter(1),None, num_lines)
+
+    def test_length_of_chunk(self):
+        num_lines_to_get = 10
+        chunks = self.chunked_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
+        chunk = next(chunks)
+        lines = chunk.split('\n')
+        self.assertEqual(len(lines), num_lines_to_get)
+        chunk = next(chunks)
+        lines = chunk.split('\n')
+        self.assertEqual(len(lines), num_lines_to_get)
+
+    def test_combined_chunk_same_as_format_tree(self):
+        num_lines_to_get = 10
+        answer = self.format_tree(ACCEPTANCE_INPUT)
+        chunks = self.chunked_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
+        result = '\n'.join((chunk for chunk in chunks))
+        self.assertEqual(result, answer)
 
 
 def d(name, files):

--- a/src/eliottree/tree_format/tests/test_text.py
+++ b/src/eliottree/tree_format/tests/test_text.py
@@ -22,7 +22,7 @@ from testtools import TestCase
 from testtools.matchers import DocTestMatches
 
 from .._text import (
-    format_tree, format_ascii_tree, chunked_format_tree
+    format_tree, format_ascii_tree, paged_format_tree
 )
 from pprint import pprint as Print
 
@@ -154,28 +154,28 @@ class TestFormatTree(TestCase):
         +-- qux
         '''), output)
 
-class TestChunkedFormatTree(TestCase):
+class TestPagedFormatTree(TestCase):
     def format_tree(self, tree):
         return format_tree(tree, itemgetter(0), itemgetter(1))
 
-    def chunked_format_tree(self, tree, num_lines):
-        return chunked_format_tree(tree, itemgetter(0), itemgetter(1),None, num_lines)
+    def paged_format_tree(self, tree, num_lines):
+        return paged_format_tree(tree, itemgetter(0), itemgetter(1),None, num_lines)
 
-    def test_length_of_chunk(self):
+    def test_length_of_page_in_paged_format_tree(self):
         num_lines_to_get = 10
-        chunks = self.chunked_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
-        chunk = next(chunks)
-        lines = chunk.split('\n')
+        pages = self.paged_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
+        page = next(pages)
+        lines = page.split('\n')
         self.assertEqual(len(lines), num_lines_to_get)
-        chunk = next(chunks)
-        lines = chunk.split('\n')
+        page = next(pages)
+        lines = page.split('\n')
         self.assertEqual(len(lines), num_lines_to_get)
 
-    def test_combined_chunk_same_as_format_tree(self):
+    def test_combined_paged_tree_same_as_format_tree(self):
         num_lines_to_get = 10
         answer = self.format_tree(ACCEPTANCE_INPUT)
-        chunks = self.chunked_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
-        result = '\n'.join((chunk for chunk in chunks))
+        pages = self.paged_format_tree(ACCEPTANCE_INPUT, num_lines_to_get)
+        result = '\n'.join((page for page in pages))
         self.assertEqual(result, answer)
 
 

--- a/src/eliottree/tree_format/tests/test_text.py
+++ b/src/eliottree/tree_format/tests/test_text.py
@@ -36,7 +36,7 @@ class TestFormatTree(TestCase):
 
     def test_single_node_tree(self):
         tree = ('foo', [])
-        output = self.format_tree(tree)
+        output = next(self.format_tree(tree))
         self.assertEqual(dedent(u'''\
         foo
         '''), output)
@@ -49,7 +49,7 @@ class TestFormatTree(TestCase):
                 ('qux', []),
             ],
         )
-        output = self.format_tree(tree)
+        output = next(self.format_tree(tree))
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -68,7 +68,7 @@ class TestFormatTree(TestCase):
                 ('qux', []),
             ],
         )
-        output = self.format_tree(tree)
+        output = next(self.format_tree(tree))
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -89,7 +89,7 @@ class TestFormatTree(TestCase):
                 ]),
             ],
         )
-        output = self.format_tree(tree)
+        output = next(self.format_tree(tree))
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -118,7 +118,7 @@ class TestFormatTree(TestCase):
                 ('qux\nfrab', []),
             ],
         )
-        output = self.format_tree(tree)
+        output = next(self.format_tree(tree))
         self.assertEqual(dedent(u'''\
         foo
         ├── bar⏎

--- a/src/eliottree/tree_format/tests/test_text.py
+++ b/src/eliottree/tree_format/tests/test_text.py
@@ -36,7 +36,7 @@ class TestFormatTree(TestCase):
 
     def test_single_node_tree(self):
         tree = ('foo', [])
-        output = next(self.format_tree(tree))
+        output = self.format_tree(tree)
         self.assertEqual(dedent(u'''\
         foo
         '''), output)
@@ -49,7 +49,7 @@ class TestFormatTree(TestCase):
                 ('qux', []),
             ],
         )
-        output = next(self.format_tree(tree))
+        output = self.format_tree(tree)
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -68,7 +68,7 @@ class TestFormatTree(TestCase):
                 ('qux', []),
             ],
         )
-        output = next(self.format_tree(tree))
+        output = self.format_tree(tree)
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -89,7 +89,7 @@ class TestFormatTree(TestCase):
                 ]),
             ],
         )
-        output = next(self.format_tree(tree))
+        output = self.format_tree(tree)
         self.assertEqual(dedent(u'''\
         foo
         ├── bar
@@ -118,7 +118,7 @@ class TestFormatTree(TestCase):
                 ('qux\nfrab', []),
             ],
         )
-        output = next(self.format_tree(tree))
+        output = self.format_tree(tree)
         self.assertEqual(dedent(u'''\
         foo
         ├── bar⏎


### PR DESCRIPTION
The purpose of this pull request is to allow the logs to be viewed as chunks. This is useful for long running tasks.

```
(eliot_tree) λ eliot-tree test.log -l 0 --chunk-size 10
82df7cd8-68b4-415c-ae30-e57f545142b4
└── start_fib/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.016s
    ├── FIB/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.003s
    │   ├── n: 10
    │   ├── FIB/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.003s
    │   │   ├── n: 9
    │   │   ├── FIB/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.003s
    │   │   │   ├── n: 8
    │   │   │   ├── FIB/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.003s
    │   │   │   │   ├── n: 7
Press any key to continue or 'X' to exit or 'T' for next task:

    │   │   │   │   ├── FIB/2/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.001s
    │   │   │   │   │   ├── n: 6
    │   │   │   │   │   ├── FIB/2/2/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.001s
    │   │   │   │   │   │   ├── n: 5
    │   │   │   │   │   │   ├── FIB/2/2/2/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.001s
    │   │   │   │   │   │   │   ├── n: 4
    │   │   │   │   │   │   │   ├── FIB/2/2/2/2/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.000s
    │   │   │   │   │   │   │   │   ├── n: 3
    │   │   │   │   │   │   │   │   ├── FIB/2/2/2/2/2/2/2/2/2/1 ⇒ started 2020-08-21 15:16:13Z ⧖ 0.000s
    │   │   │   │   │   │   │   │   │   ├── n: 2
Press any key to continue or 'X' to exit or 'T' for next task:
```

to make the log for the example I ran the code below several times
```
from pathlib import Path
from eliot import log_call, to_file, log_message, start_task, start_action
to_file(Path("test.log").open("ab+"))

@log_call(action_type="FIB", include_args=['n'], include_result=True)
def fib(n):
    if n==1 or n==0:
        return n
    return n+fib(n-1)

def main(n):
    with start_task(action_type="start_fib") as task:
        n = fib(n)
        task.log(message_type='result', n=n)
    print(n)

if __name__=='__main__':
    main(30)

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonathanj/eliottree/99)
<!-- Reviewable:end -->
