### PR TITLE
fix: --color=always does not always output color

### DIFF
--- a/src/eliottree/_color.py
+++ b/src/eliottree/_color.py
@@ -1,6 +1,9 @@
 import colored as _colored
 
 
+# Disable `colored` TTY awareness, since we handle this ourselves.
+_colored.set_tty_aware(awareness=False)
+
 attr_codes = {
     'bold': 1,
     'dim': 2,


### PR DESCRIPTION
The `colored` dependency has its own ideas about TTY awareness. This should be disabled since eliottree already handles these concerns and lets the user make their own decisions.

Fixes #106 
